### PR TITLE
Typo fix in Docs & Scss Class: "optaional" to "optional"

### DIFF
--- a/src/views/APIView.js
+++ b/src/views/APIView.js
@@ -57,7 +57,7 @@ class APIView extends Component {
         <p className="header">
           <span className="title">{entry.name}</span>
           <span className="type">{entry.type}</span>
-          {entry.isOptional ? <em className="optaional">optaional</em> : null}
+          {entry.isOptional ? <em className="optional">optional</em> : null}
         </p>
         <p className="desc">{entry.desc}</p>
         {entry.defaultVal && (entry.defaultVal !== 'null' && entry.defaultVal !== 'undefined') ? (

--- a/src/views/APIView.scss
+++ b/src/views/APIView.scss
@@ -32,7 +32,7 @@
           padding-left: 20px;
           color: #bf2a5c;
         }
-        .optaional {
+        .optional {
           margin-left: 10px;
         }
       }


### PR DESCRIPTION
Spotted a typo on the website. In a few areas it said optaional instead of optional.