### PR TITLE
Dynamic Titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "pure-render-decorator": "~1.1.1",
     "react": "~15.0.2",
     "react-dom": "~15.0.2",
+    "react-helmet": "^3.1.0",
     "react-redux": "~4.4.5",
     "react-router": "~2.3.0",
     "react-router-redux": "~4.0.4",

--- a/src/layouts/Frame.js
+++ b/src/layouts/Frame.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { browserHistory } from 'react-router';
+import Helmet from 'react-helmet';
 import Link from 'utils/Link';
 import 'styles/app.scss';
 
@@ -20,6 +21,7 @@ class Frame extends Component {
 
     return (
       <div className="container">
+        <Helmet titleTemplate={'%s | Recharts'} />
         <header>
           <div className="header-wrapper">
             <h1 className="logo">

--- a/src/views/APIView.js
+++ b/src/views/APIView.js
@@ -1,5 +1,6 @@
 import React, { PropTypes, cloneElement, Component } from 'react';
 import { connect } from 'react-redux';
+import Helmet from 'react-helmet';
 import API from 'docs/api';
 import Highlight from 'utils/Highlight';
 import pureRender from 'pure-render-decorator';
@@ -92,6 +93,7 @@ class APIView extends Component {
 
     return (
       <div className="page page-api">
+        <Helmet title={page} />
         <div className="sidebar">
           <h2>API</h2>
           <h4>Charts</h4>

--- a/src/views/ExamplesView.js
+++ b/src/views/ExamplesView.js
@@ -1,5 +1,6 @@
 import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
+import Helmet from 'react-helmet';
 import pureRender from 'pure-render-decorator';
 import Examples from 'docs/examples';
 
@@ -38,6 +39,7 @@ class ExamplesView extends Component {
 
     return (
       <div className="page page-examples">
+        <Helmet title={page} />
         <div className="sidebar">
           <h2>Examples</h2>
 


### PR DESCRIPTION
If you open up multiple api/example tabs it can get confusing because all tabs just say `Recharts`. This PR makes the title dynamic  (`%s | Recharts`) to whatever api/example page you're on.