### PR TITLE
default dot property is true

### DIFF
--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -43,7 +43,7 @@ export default {
     }, {
       name: 'dot',
       type: 'Boolean | Object | ReactElement | Function',
-      defaultVal: 'false',
+      defaultVal: 'true',
       isOptional: false,
       desc: 'If false set, dots will not be drawn. If true set, dots will be drawn which have the props calculated internally. If object set, dots will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom dot element.If set a function, the function will be called to render customized dot.',
       format: [


### PR DESCRIPTION
Documentation incorrectly states that dot is set to false by default. The default prop is actually set to true:
https://github.com/recharts/recharts/blob/580ac55e4374ef2ef9ebeaf0adda8bc35f1ca36d/src/cartesian/Line.js#L79

Cheers!