### PR TITLE
Fix typo in the doc of Legend

### DIFF
--- a/src/docs/api/Legend.js
+++ b/src/docs/api/Legend.js
@@ -56,7 +56,7 @@ export default {
       type: 'Number',
       defaultVal: 'null',
       isOptional: true,
-      desc: 'The width of legend.',
+      desc: 'The height of legend.',
     }, {
       name: 'layout',
       type: '\'horizontal\', \'vertical\'',


### PR DESCRIPTION
The description of the property `height` should be "The height of legend."
