### PR TITLE
Make docs better machine-readable

### DIFF
--- a/src/docs/api/Area.js
+++ b/src/docs/api/Area.js
@@ -111,7 +111,7 @@ export default {
       },
     }, {
       name: 'layout',
-      type: `'horizontal', 'vertical'`,
+      type: `'horizontal' | 'vertical'`,
       defaultVal: 'undefined',
       isOptional: true,
       desc: {
@@ -223,7 +223,7 @@ export default {
       },
     }, {
       name: 'animationEasing',
-      type: `'ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear'`,
+      type: `'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear'`,
       defaultVal: `'ease'`,
       isOptional: false,
       desc: {

--- a/src/docs/api/AreaChart.js
+++ b/src/docs/api/AreaChart.js
@@ -69,7 +69,7 @@ export default {
       format: ['{ top: 5, right: 5, bottom: 5, left: 5 }'],
     }, {
       name: 'stackOffset',
-      type: `'expand', 'none', 'wiggle', 'silhouette'`,
+      type: `'expand' | 'none' | 'wiggle' | 'silhouette'`,
       defaultVal: `'none'`,
       isOptional: false,
       desc: {

--- a/src/docs/api/AreaChart.js
+++ b/src/docs/api/AreaChart.js
@@ -7,7 +7,7 @@ export default {
   props: [
     {
       name: 'layout',
-      type: '\'horizontal\' , \'vertical\'',
+      type: '\'horizontal\' | \'vertical\'',
       defaultVal: '\'horizontal\'',
       isOptional: false,
       desc: {

--- a/src/docs/api/Bar.js
+++ b/src/docs/api/Bar.js
@@ -3,7 +3,7 @@ export default {
   props: [
     {
       name: 'layout',
-      type: '\'horizontal\' , \'vertical\'',
+      type: '\'horizontal\' | \'vertical\'',
       defaultVal: 'undefined',
       isOptional: true,
       desc: {

--- a/src/docs/api/Bar.js
+++ b/src/docs/api/Bar.js
@@ -177,7 +177,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US': 'Specifies when the animation should begin, the unit of this option is ms.',
-        'zh-CN': '声明组件挂载或更新后，开始运行动画的间隔时长，单位为毫秒。',
+        'zh-CN': '声明组件挂载或更新���，开始运行动画的间隔时长，单位为毫秒。',
       },
     }, {
       name: 'animationDuration',
@@ -190,7 +190,7 @@ export default {
       },
     }, {
       name: 'animationEasing',
-      type: `'ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear'`,
+      type: `'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear'`,
       defaultVal: `'ease'`,
       isOptional: false,
       desc: {

--- a/src/docs/api/BarChart.js
+++ b/src/docs/api/BarChart.js
@@ -3,7 +3,7 @@ export default {
   props: [
     {
       name: 'layout',
-      type: '\'horizontal\' , \'vertical\'',
+      type: '\'horizontal\' | \'vertical\'',
       defaultVal: '\'horizontal\'',
       isOptional: false,
       desc: {

--- a/src/docs/api/BarChart.js
+++ b/src/docs/api/BarChart.js
@@ -111,7 +111,7 @@ export default {
       },
     }, {
       name: 'stackOffset',
-      type: `'expand', 'none', 'wiggle', 'silhouette', 'sign'`,
+      type: `'expand' | 'none' | 'wiggle' | 'silhouette' | 'sign'`,
       defaultVal: `'none'`,
       isOptional: false,
       desc: {

--- a/src/docs/api/CartesianAxis.js
+++ b/src/docs/api/CartesianAxis.js
@@ -39,7 +39,7 @@ export default {
       },
     }, {
       name: 'orientation',
-      type: '\'top\', \'bottom\', \'left\' or \'right\'',
+      type: '\'top\' | \'bottom\' | \'left\' | \'right\'',
       defaultVal: '\'bottom\'',
       isOptional: false,
       desc: {

--- a/src/docs/api/ComposedChart.js
+++ b/src/docs/api/ComposedChart.js
@@ -4,7 +4,7 @@ export default {
   props: [
     {
       name: 'layout',
-      type: '\'horizontal\' , \'vertical\'',
+      type: '\'horizontal\' | \'vertical\'',
       defaultVal: '\'horizontal\'',
       isOptional: false,
       desc: {

--- a/src/docs/api/Curve.js
+++ b/src/docs/api/Curve.js
@@ -29,7 +29,7 @@ export default {
       },
     }, {
       name: 'layout',
-      type: `'horizontal', 'vertical'`,
+      type: `'horizontal' | 'vertical'`,
       defaultVal: 'null',
       isOptional: true,
       desc: {

--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -124,7 +124,7 @@ export default {
       format: [`[{x: 12, y: 12, value: 240}]`],
     }, {
       name: 'layout',
-      type: `'horizontal', 'vertical'`,
+      type: `'horizontal' | 'vertical'`,
       defaultVal: 'undefined',
       isOptional: true,
       desc: {
@@ -191,7 +191,7 @@ export default {
       },
     }, {
       name: 'animationEasing',
-      type: `'ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear'`,
+      type: `'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear'`,
       defaultVal: `'ease'`,
       isOptional: false,
       desc: {

--- a/src/docs/api/LineChart.js
+++ b/src/docs/api/LineChart.js
@@ -3,7 +3,7 @@ export default {
   props: [
     {
       name: 'layout',
-      type: '\'horizontal\' , \'vertical\'',
+      type: '\'horizontal\' | \'vertical\'',
       defaultVal: '\'horizontal\'',
       isOptional: false,
       desc: {

--- a/src/docs/api/Pie.js
+++ b/src/docs/api/Pie.js
@@ -194,7 +194,7 @@ export default {
       },
     }, {
       name: 'animationEasing',
-      type: `'ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear' | Function`,
+      type: `'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear' | Function`,
       defaultVal: `'ease'`,
       isOptional: false,
       desc: {

--- a/src/docs/api/PolarGrid.js
+++ b/src/docs/api/PolarGrid.js
@@ -57,7 +57,7 @@ export default {
       },
     }, {
       name: 'gridType',
-      type: `'polygon', 'circle'`,
+      type: `'polygon' | 'circle'`,
       defaultVal: 'polygon',
       isOptional: false,
       desc: {

--- a/src/docs/api/Radar.js
+++ b/src/docs/api/Radar.js
@@ -75,7 +75,7 @@ export default {
       },
     }, {
       name: 'animationEasing',
-      type: `'ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear'`,
+      type: `'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear'`,
       defaultVal: `'ease'`,
       isOptional: false,
       desc: {

--- a/src/docs/api/RadialBar.js
+++ b/src/docs/api/RadialBar.js
@@ -120,7 +120,7 @@ export default {
       },
     }, {
       name: 'animationEasing',
-      type: `'ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear'`,
+      type: `'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear'`,
       defaultVal: `'ease'`,
       isOptional: false,
       desc: {

--- a/src/docs/api/Scatter.js
+++ b/src/docs/api/Scatter.js
@@ -121,7 +121,7 @@ export default {
       },
     }, {
       name: 'animationEasing',
-      type: `'ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear'`,
+      type: `'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear'`,
       defaultVal: `'ease'`,
       isOptional: false,
       desc: {

--- a/src/docs/api/Text.js
+++ b/src/docs/api/Text.js
@@ -30,12 +30,12 @@ export default {
       },
     }, {
       name: 'textAnchor',
-      type: `'start', 'middle', 'end', 'inherit'`,
+      type: `'start' | 'middle' | 'end' | 'inherit'`,
       defaultVal: 'start',
       isOptional: false,
     }, {
       name: 'verticalAnchor',
-      type: `'start', 'middle', 'end'`,
+      type: `'start' | 'middle' | 'end'`,
       defaultVal: 'end',
       isOptional: false,
     },

--- a/src/docs/api/Tooltip.js
+++ b/src/docs/api/Tooltip.js
@@ -202,7 +202,7 @@ export default {
       },
     }, {
       name: 'animationEasing',
-      type: `'ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear'`,
+      type: `'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear'`,
       defaultVal: `'ease'`,
       isOptional: false,
       desc: {

--- a/src/docs/api/Treemap.js
+++ b/src/docs/api/Treemap.js
@@ -66,7 +66,7 @@ export default {
       },
     }, {
       name: 'animationEasing',
-      type: `'ease', 'ease-in', 'ease-out', 'ease-in-out', 'linear'`,
+      type: `'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear'`,
       defaultVal: `'ease'`,
       isOptional: false,
       desc: {

--- a/src/docs/api/XAxis.js
+++ b/src/docs/api/XAxis.js
@@ -57,7 +57,7 @@ export default {
       },
     }, {
       name: 'type',
-      type: '\'number\' , \'category\'',
+      type: '\'number\' | \'category\'',
       defaultVal: '\'category\'',
       isOptional: false,
       desc: {

--- a/src/docs/api/YAxis.js
+++ b/src/docs/api/YAxis.js
@@ -48,7 +48,7 @@ export default {
       },
     }, {
       name: 'orientation',
-      type: '\'left\' , \'right\'',
+      type: '\'left\' | \'right\'',
       defaultVal: '\'left\'',
       isOptional: false,
       desc: {
@@ -57,7 +57,7 @@ export default {
       },
     }, {
       name: 'type',
-      type: '\'number\' , \'category\'',
+      type: '\'number\' | \'category\'',
       defaultVal: '\'number\'',
       isOptional: false,
       desc: {


### PR DESCRIPTION
I'm attempting to extract [TypeScript](http://www.typescriptlang.org/) definitions from the current API documentation. The current API docs are quite easy to parse for machines so I suppose it should be possible.

During the process, I've encountered a few cases where the word 'or' is used in a type definition; I would propose to replace that by `|` to facilitate easier machine processing.