### PR TITLE
Clarify wording of allowDataOverflow description

### DIFF
--- a/src/docs/api/XAxis.js
+++ b/src/docs/api/XAxis.js
@@ -79,7 +79,7 @@ export default {
       defaultVal: 'false',
       isOptional: false,
       desc: {
-        'en-US': `When specify the domain of axis and the type of axis is number, if allowDataOverflow is set to be false, we'll adjust the domain when the minimum value of data is smaller than domain[0] or the maximum value of data is greater than domain[1]. If set true, the graphic elements (line, area, bars) will be clipped to fix the specified domain.`,
+        'en-US': `When domain of the axis is specified and the type of the axis is 'number', if allowDataOverflow is set to be false, the domain will be adjusted when the minimum value of data is smaller than domain[0] or the maximum value of data is greater than domain[1] so that the axis displays all data values. If set to true, graphic elements (line, area, bars) will be clipped to conform to the specified domain.`,
         'zh-CN': '当轴是数值轴时，指定轴的定义域（domain）的时候，如果 allowDataOverflow 的值为 false，我们会根据数据的最大值和最小值来调整 domain，确保所有的数据能够展示。如果 allowDataOverflow 的值为 true，不会调整 domain ，而是将相应的图形元素会直接裁剪掉。',
       },
     }, {

--- a/src/docs/api/YAxis.js
+++ b/src/docs/api/YAxis.js
@@ -143,7 +143,7 @@ export default {
       defaultVal: 'false',
       isOptional: false,
       desc: {
-        'en-US': `When specify the domain of axis and the type of axis is number, if allowDataOverflow is set to be false, we'll adjust the domain when the minimum value of data is smaller than domain[0] or the maximum value of data is greater than domain[1]. If set true, the graphic elements (line, area, bars) will be clipped to fix the specified domain.`,
+        'en-US': `When domain of the axis is specified and the type of the axis is 'number', if allowDataOverflow is set to be false, the domain will be adjusted when the minimum value of data is smaller than domain[0] or the maximum value of data is greater than domain[1] so that the axis displays all data values. If set to true, graphic elements (line, area, bars) will be clipped to conform to the specified domain.`,
         'zh-CN': '当轴是数值轴时，指定轴的定义域（domain）的时候，如果 allowDataOverflow 的值为 false，我们会根据数据的最大值和最小值来调整 domain，确保所有的数据能够展示。如果 allowDataOverflow 的值为 true，不会调整 domain ，而是将相应的图形元素会直接裁剪掉。',
       },
     }, {


### PR DESCRIPTION
The wording for `allowDataOverflow` in the `XAxis` and `YAxis` is a little terse and difficult to understand.

This change modifies the description slightly to improve clarity.