### PR TITLE
feat: adds documentation for reverseGroupOrder, fix #873

### DIFF
--- a/src/docs/api/BarChart.js
+++ b/src/docs/api/BarChart.js
@@ -127,13 +127,13 @@ export default {
         isExternal: true,
       }],
     }, {
-      name: 'reverseGroupOrder',
+      name: 'reverseStackOrder',
       type: 'Boolean',
       defaultVal: 'false',
       isOptional: true,
       desc: {
-        'en-US': 'If false set, grouped items will be rendered left to right. If true set, grouped items will be rendered right to left. (Render direction affects SVG layering, not x position.)',
-        'zh-CN': '如果设置为false，则分组的项目将从左到右呈现。如果设置为true，则分组的项目将从右到左呈现。 （渲染方向影响SVG分层，而不影响x位置。）',
+        'en-US': 'If false set, stacked items will be rendered left to right. If true set, stacked items will be rendered right to left. (Render direction affects SVG layering, not x position.)',
+        'zh-CN': '如果设置为false，堆叠的项目将从左到右呈现。如果真正设置，堆叠的项目将从右到左呈现。 （渲染方向影响SVG分层，而不影响x位置。）',
       },
     }, {
       name: 'onClick',

--- a/src/docs/api/BarChart.js
+++ b/src/docs/api/BarChart.js
@@ -127,6 +127,15 @@ export default {
         isExternal: true,
       }],
     }, {
+      name: 'reverseGroupOrder',
+      type: 'Boolean',
+      defaultVal: 'false',
+      isOptional: true,
+      desc: {
+        'en-US': 'If false set, grouped items will be rendered left to right. If true set, grouped items will be rendered right to left. (Render direction affects SVG layering, not x position.)',
+        'zh-CN': '如果设置为false，则分组的项目将从左到右呈现。如果设置为true，则分组的项目将从右到左呈现。 （渲染方向影响SVG分层，而不影响x位置。）',
+      },
+    }, {
       name: 'onClick',
       type: 'Function',
       isOptional: true,

--- a/src/docs/api/ComposedChart.js
+++ b/src/docs/api/ComposedChart.js
@@ -89,13 +89,13 @@ export default {
         'zh-CN': '柱条的宽度。如果指定这个值，会根据 barCategoryGap 和 barGap 来计算柱条的宽度，每组柱条的宽度是一样的。'
       },
     }, {
-      name: 'reverseGroupOrder',
+      name: 'reverseStackOrder',
       type: 'Boolean',
       defaultVal: 'false',
       isOptional: true,
       desc: {
-        'en-US': 'If false set, grouped items will be rendered left to right. If true set, grouped items will be rendered right to left. (Render direction affects SVG layering, not x position.)',
-        'zh-CN': '如果设置为false，则分组的项目将从左到右呈现。如果设置为true，则分组的项目将从右到左呈现。 （渲染方向影响SVG分层，而不影响x位置。）',
+        'en-US': 'If false set, stacked items will be rendered left to right. If true set, stacked items will be rendered right to left. (Render direction affects SVG layering, not x position.)',
+        'zh-CN': '如果设置为false，堆叠的项目将从左到右呈现。如果真正设置，堆叠的项目将从右到左呈现。 （渲染方向影响SVG分层，而不影响x位置。）',
       },
     }, {
       name: 'onClick',

--- a/src/docs/api/ComposedChart.js
+++ b/src/docs/api/ComposedChart.js
@@ -89,6 +89,15 @@ export default {
         'zh-CN': '柱条的宽度。如果指定这个值，会根据 barCategoryGap 和 barGap 来计算柱条的宽度，每组柱条的宽度是一样的。'
       },
     }, {
+      name: 'reverseGroupOrder',
+      type: 'Boolean',
+      defaultVal: 'false',
+      isOptional: true,
+      desc: {
+        'en-US': 'If false set, grouped items will be rendered left to right. If true set, grouped items will be rendered right to left. (Render direction affects SVG layering, not x position.)',
+        'zh-CN': '如果设置为false，则分组的项目将从左到右呈现。如果设置为true，则分组的项目将从右到左呈现。 （渲染方向影响SVG分层，而不影响x位置。）',
+      },
+    }, {
       name: 'onClick',
       type: 'Function',
       isOptional: true,


### PR DESCRIPTION
## Related
* https://github.com/recharts/recharts/issues/873
* https://github.com/recharts/recharts/pull/874
* http://jsfiddle.net/jayseeg/oc5jtdrz/1/

## Feature
Given a bar chart with multiple bars
When I overlap the bars with a negative bar gap to achieve a layered effect
Then I want to be able to tell the chart which order to render the SVG elements in (calling for reverse rendering should render right to left without changing coordinates so that left most elements can layer on top of elements to the right)

## Details
Added documentation for  `reverseGroupOrder` boolean prop to Bar Chart & Composed Chart API docs.

## Notes
I pulled the Chinese translation out of Google translate,... YMMV.