### PR TITLE
Fixes English string typo for activeDot section in Line.js docs

### DIFF
--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -80,7 +80,7 @@ export default {
       defaultVal: 'true',
       isOptional: false,
       desc: {
-        'en-US': 'The dot is shown when muser enter a line chart and this chart has tooltip. If false set, no active dot will not be drawn. If true set, active dot will be drawn which have the props calculated internally. If object set, active dot will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom active dot element.If set a function, the function will be called to render customized active dot.',
+        'en-US': 'The active dot is shown when a user enters a line chart and this chart has tooltip. If set to false, no active dot will be drawn. If set to true, active dot will be drawn with the props calculated internally. If passed an object, active dot will be drawn, and the internally calculated props will be merged with the key value pairs of the passed object. If passed a ReactElement, the option can be the custom active dot element. If passed a function, the function will be called to render a customized active dot.',
         'zh-CN': '当图表触发mouseenter事件，并且需要展示 Tooltip 的时候，会展示一个“激活状态的点”。当值为 false ，不渲染“激活状态的点”。当值为 true ，点会继承 Line 的属性配置，例如配置了 Line 的 stroke 为 "red"， 点会继承这个属性。当值为一个对象的时候，会把这个对象解析为点的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“点”。当值是一个 函数 时，会调用这个函数去渲染自定义的“点”。',
       },
       format: [


### PR DESCRIPTION
This addresses issue #59 

Please let me know if the wording should be changed again, or if anything else should be different in this pull request. Thanks!