### PR TITLE
Shift to using hashRouter so that docs can be deep linked and the window refreshed

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ import "babel-polyfill";
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { applyRouterMiddleware, browserHistory } from 'react-router';
+import { applyRouterMiddleware, hashHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 import { useScroll } from 'react-router-scroll';
 import makeRoutes from './routes';
@@ -10,8 +10,8 @@ import Root from './containers/Root';
 import configureStore from './redux/configureStore';
 
 const initialState = window.__INITIAL_STATE__
-const store = configureStore(initialState, browserHistory)
-const history = syncHistoryWithStore(browserHistory, store, {
+const store = configureStore(initialState, hashHistory)
+const history = syncHistoryWithStore(hashHistory, store, {
   selectLocationState: (state) => state.router,
 });
 


### PR DESCRIPTION
Fixes https://github.com/recharts/recharts.org/issues/56

I note there is some discussion in https://github.com/recharts/recharts/issues/1279 and https://github.com/recharts/recharts/issues/1280 regarding other solutions, however a tweak to use hashHistory instead of browserHiistory seems to fix this for me, at least when running locally:

![untitled](https://user-images.githubusercontent.com/1094901/40354303-b76f7b4c-5ddd-11e8-9ca3-72761cfe3dde.gif)