### PR TITLE
Added LabelProps object to X/YAxis label prop

### DIFF
--- a/src/docs/api/XAxis.js
+++ b/src/docs/api/XAxis.js
@@ -240,16 +240,17 @@ export default {
       }
     }, {
       name: 'label',
-      type: 'String | Number | ReactElement',
+      type: 'String | Number | ReactElement | Object',
       defaultVal: 'null',
       isOptional: true,
       desc: {
-        'en-US': 'If set a string or a number, default label will be drawn, and the option is content. If set a React element, the option is the custom react element of drawing label.',
-        'zh-CN': '当值为简单类型的数值或者字符串时，这个值会被渲染成文字标签。当值为 React element，会克隆这个元素来渲染文字标签。',
+        'en-US': 'If set a string or a number, default label will be drawn, and the option is content. If set a React element, the option is the custom react element of drawing label. If an object, the option is the props of a new Label instance.',
+        'zh-CN': '当值为简单类型的数值或者字符串时，这个值会被渲染成文字标签。当值为 React element，会克隆这个元素来渲染文字标签。如果一个对象，该选项是一个新的Label实例的道具。',
       },
       format: [
         `<XAxis label="Height" />`,
         `<XAxis label={<CustomizedLabel />} />`,
+        `<XAxis label={{ value: "XAxis Label" }} />`,
       ],
       examples: [
         {

--- a/src/docs/api/YAxis.js
+++ b/src/docs/api/YAxis.js
@@ -235,16 +235,17 @@ export default {
       }
     }, {
       name: 'label',
-      type: 'String | Number | ReactElement',
+      type: 'String | Number | ReactElement | Object',
       defaultVal: 'null',
       isOptional: true,
       desc: {
-        'en-US': 'If set a string or a number, default label will be drawn, and the option is content. If set a React element, the option is the custom react element of drawing label.',
-        'zh-CN': '当值为简单类型的数值或者字符串时，这个值会被渲染成文字标签。当值为 React element，会克隆这个元素来渲染文字标签。',
+        'en-US': 'If set a string or a number, default label will be drawn, and the option is content. If set a React element, the option is the custom react element of drawing label. If an object, the option is the props of a new Label instance.',
+        'zh-CN': '当值为简单类型的数值或者字符串时，这个值会被渲染成文字标签。当值为 React element，会克隆这个元素来渲染文字标签。如果一个对象，该选项是一个新的Label实例的道具。',
       },
       format: [
         `<YAxis label="Height" />`,
         `<YAxis label={<CustomizedLabel />} />`,
+        `<YAxis label={{ value: "YAxis Label" }} />`,
       ],
       examples: [
         {


### PR DESCRIPTION
On both `XAxis` and `YAxis`, the `label` prop can be an object of type [`LabelProps`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/recharts/index.d.ts#L834) in addition to existing types.

[Source code reference](https://github.com/recharts/recharts/blob/03e554401a1b97e116746710247df0dd544b10dc/src/component/Label.js#L373), and [issue mention](https://github.com/recharts/recharts/issues/184).

A PR to update the relvant typedefs has also been [submitted here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26329)