### PR TITLE
tickCount prop is not used when axis type categorical

### DIFF
--- a/src/docs/api/PolarRadiusAxis.js
+++ b/src/docs/api/PolarRadiusAxis.js
@@ -111,8 +111,8 @@ export default {
       defaultVal: 5,
       isOptional: false,
       desc: {
-        'en-US': 'The count of axis ticks.',
-        'zh-CN': '刻度数。',
+        'en-US': `The count of axis ticks. Not used if 'type' is 'category'.`,
+        'zh-CN': `刻度数。如果'type'是'category'，则不使用。`,
       },
     }, {
       name: 'scale',

--- a/src/docs/api/XAxis.js
+++ b/src/docs/api/XAxis.js
@@ -97,8 +97,8 @@ export default {
       defaultVal: '5',
       isOptional: false,
       desc: {
-        'en-US': 'The count of axis ticks.',
-        'zh-CN': '刻度数。',
+        'en-US': `The count of axis ticks. Not used if 'type' is 'category'.`,
+        'zh-CN': `刻度数。如果'type'是'category'，则不使用。`,
       },
     }, {
       name: 'domain',

--- a/src/docs/api/YAxis.js
+++ b/src/docs/api/YAxis.js
@@ -70,8 +70,8 @@ export default {
       defaultVal: '5',
       isOptional: false,
       desc: {
-        'en-US': 'The count of axis ticks.',
-        'zh-CN': '刻度数。',
+        'en-US': `The count of axis ticks. Not used if 'type' is 'category'.`,
+        'zh-CN': `刻度数。如果'type'是'category'，则不使用。`,
       },
       name: 'domain',
       type: 'Array',


### PR DESCRIPTION
Mentioned in recharts issue https://github.com/recharts/recharts/issues/50

As far as I can see, the type of axis/scale is checked in a couple of places - in each case if the type is `category`, `tickCount` is unused:
- [Axis Ticks](https://github.com/recharts/recharts/blob/master/src/util/ChartUtils.js#L487)
- [Scale Ticks](https://github.com/recharts/recharts/blob/master/src/util/ChartUtils.js#L756)
