### PR TITLE
Fixed minor typo

### DIFF
--- a/src/docs/api/YAxis.js
+++ b/src/docs/api/YAxis.js
@@ -126,7 +126,7 @@ export default {
       defaultVal: '5',
       isOptional: false,
       desc: {
-        'en-US': 'The minimum gab between two adjacent labels.',
+        'en-US': 'The minimum gap between two adjacent labels.',
         'zh-CN': '两个刻度之前最小间隔宽度。',
       },
     }, {


### PR DESCRIPTION
There was a typo in the docs for `yAxis`. Fixed `gab` => `gap`