### PR TITLE
update lib version on Index page

### DIFF
--- a/src/views/IndexView.js
+++ b/src/views/IndexView.js
@@ -55,7 +55,7 @@ class IndexView extends PureComponent {
               {' '}
               {localeGet(locale, 'home', 'install')}
               {' '}
-v1.3.5
+v1.4.2
             </Link>
           </p>
           <iframe title="star" src="https://ghbtns.com/github-btn.html?user=recharts&repo=recharts&type=star&count=true&size=median" frameBorder="0" scrolling="0" width="120px" height="22px" />


### PR DESCRIPTION
Currently website states that `1.3.5` is the latest release. This PR bumps displayed version to `1.4.2`.