### PR TITLE
Add Stroke Width Option

### DIFF
--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -123,6 +123,16 @@ export default {
       },
       format: ['[{x: 12, y: 12, value: 240}]'],
     }, {
+      name: 'strokeWidth',
+      type: 'number',
+      defaultVal: '1',
+      isOptional: true,
+      desc: {
+        'en-US': 'The width of the stroke',
+        'zh-CN': '虚线的宽度',
+      },
+      format: ['[{x: 12, y: 12, value: 240}]'],
+    },{
       name: 'layout',
       type: '\'horizontal\' | \'vertical\'',
       defaultVal: 'undefined',

--- a/src/docs/api/ReferenceLine.js
+++ b/src/docs/api/ReferenceLine.js
@@ -104,6 +104,15 @@ export default {
         'en-US': 'If set true, the line will be rendered in front of bars in BarChart, etc.',
         'zh-CN': '是否展示在图表的最上层。',
       },
+    },{
+      name: 'strokeWidth',
+      type: 'Number',
+      defaultVal: '1',
+      isOptional: true,
+      desc: {
+        'en-US': 'The width of the stroke',
+        'zh-CN': '虚线的宽度',
+      },
     },
   ],
   parentComponents: [


### PR DESCRIPTION
The `strokeWidth` option is missing in some parts of the documentation. Sometimes can be pretty handy, and if the user that works with the library is not very familiarized with SVG, that can help her/him to apply faster and see results 