### PR TITLE
Fix typo in custom bar chart import

### DIFF
--- a/src/components/GuideView/Customize.js
+++ b/src/components/GuideView/Customize.js
@@ -40,7 +40,7 @@ function Customize({ locale }) {
       <div className="demo">
         <Highlight className="e4x">
           {
-`import { BarChart, Bar, XAxis, XAxis } from 'recharts';
+`import { BarChart, Bar, XAxis, YAxis } from 'recharts';
 const data = [{name: 'Page A', uv: 400, pv: 2400, amt: 2400}, ...];
 const renderCustomAxisTick = ({ x, y, payload }) => {
   let path = '';


### PR DESCRIPTION
`XAxis` was mistakenly imported twice  👀 