### PR TITLE
Fix typo: Replace "animtion" with "animation"

### DIFF
--- a/src/docs/api/Area.js
+++ b/src/docs/api/Area.js
@@ -244,7 +244,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion start',
+        'en-US': 'The customized event handler of animation start',
         'zh-CN': '区域图动画 start 事件的回调函数。',
       },
     }, {
@@ -252,7 +252,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion end',
+        'en-US': 'The customized event handler of animation end',
         'zh-CN': '区域图动画 end 事件的回调函数。',
       },
     }, {

--- a/src/docs/api/Bar.js
+++ b/src/docs/api/Bar.js
@@ -226,7 +226,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion start',
+        'en-US': 'The customized event handler of animation start',
         'zh-CN': '区域图动画 start 事件的回调函数。',
       },
     }, {
@@ -234,7 +234,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion end',
+        'en-US': 'The customized event handler of animation end',
         'zh-CN': '区域图动画 end 事件的回调函数。',
       },
     }, {

--- a/src/docs/api/Funnel.js
+++ b/src/docs/api/Funnel.js
@@ -107,7 +107,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion start',
+        'en-US': 'The customized event handler of animation start',
         'zh-CN': '区域图动画 start 事件的回调函数。',
       },
     }, {
@@ -115,7 +115,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion end',
+        'en-US': 'The customized event handler of animation end',
         'zh-CN': '区域图动画 end 事件的回调函数。',
       },
     }, {

--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -222,7 +222,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion start',
+        'en-US': 'The customized event handler of animation start',
         'zh-CN': '区域图动画 start 事件的回调函数。',
       },
     }, {
@@ -230,7 +230,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion end',
+        'en-US': 'The customized event handler of animation end',
         'zh-CN': '区域图动画 end 事件的回调函数。',
       },
     }, {

--- a/src/docs/api/Pie.js
+++ b/src/docs/api/Pie.js
@@ -215,7 +215,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion start',
+        'en-US': 'The customized event handler of animation start',
         'zh-CN': '区域图动画 start 事件的回调函数。',
       },
     }, {
@@ -223,7 +223,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion end',
+        'en-US': 'The customized event handler of animation end',
         'zh-CN': '区域图动画 end 事件的回调函数。',
       },
     }, {

--- a/src/docs/api/Radar.js
+++ b/src/docs/api/Radar.js
@@ -97,7 +97,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion start',
+        'en-US': 'The customized event handler of animation start',
         'zh-CN': '区域图动画 start 事件的回调函数。',
       },
     }, {
@@ -105,7 +105,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion end',
+        'en-US': 'The customized event handler of animation end',
         'zh-CN': '区域图动画 end 事件的回调函数。',
       },
     },

--- a/src/docs/api/RadialBar.js
+++ b/src/docs/api/RadialBar.js
@@ -137,7 +137,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion start',
+        'en-US': 'The customized event handler of animation start',
         'zh-CN': '区域图动画 start 事件的回调函数。',
       },
     }, {
@@ -145,7 +145,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion end',
+        'en-US': 'The customized event handler of animation end',
         'zh-CN': '区域图动画 end 事件的回调函数。',
       },
     }, {

--- a/src/docs/api/Treemap.js
+++ b/src/docs/api/Treemap.js
@@ -78,7 +78,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion start',
+        'en-US': 'The customized event handler of animation start',
         'zh-CN': '区域图动画 start 事件的回调函数。',
       },
     }, {
@@ -86,7 +86,7 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of animtion end',
+        'en-US': 'The customized event handler of animation end',
         'zh-CN': '区域图动画 end 事件的回调函数。',
       },
     },


### PR DESCRIPTION
Someone forgot the second 'a' in animation :)

Thanks for all you do! Recharts is awesome :slightly_smiling_face: 