### PR TITLE
apiExamples / BarChart: remove unused "amt" key from "data" array

### DIFF
--- a/src/docs/apiExamples/BarChart.js
+++ b/src/docs/apiExamples/BarChart.js
@@ -5,25 +5,25 @@ import {
 
 const data = [
   {
-    name: 'Page A', uv: 4000, pv: 2400, amt: 2400,
+    name: 'Page A', uv: 4000, pv: 2400,
   },
   {
-    name: 'Page B', uv: 3000, pv: 1398, amt: 2210,
+    name: 'Page B', uv: 3000, pv: 1398,
   },
   {
-    name: 'Page C', uv: 2000, pv: 9800, amt: 2290,
+    name: 'Page C', uv: 2000, pv: 9800,
   },
   {
-    name: 'Page D', uv: 2780, pv: 3908, amt: 2000,
+    name: 'Page D', uv: 2780, pv: 3908,
   },
   {
-    name: 'Page E', uv: 1890, pv: 4800, amt: 2181,
+    name: 'Page E', uv: 1890, pv: 4800,
   },
   {
-    name: 'Page F', uv: 2390, pv: 3800, amt: 2500,
+    name: 'Page F', uv: 2390, pv: 3800,
   },
   {
-    name: 'Page G', uv: 3490, pv: 4300, amt: 2100,
+    name: 'Page G', uv: 3490, pv: 4300,
   },
 ];
 


### PR DESCRIPTION
Since no `Bar` with "amt" data is used, remove `amt` key from `data` array