### PR TITLE
fix: fix example format for prop strokeWidth

### DIFF
--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -131,7 +131,8 @@ export default {
         'en-US': 'The width of the stroke',
         'zh-CN': '虚线的宽度',
       },
-      format: ['[{x: 12, y: 12, value: 240}]'],
+      format: ['<Line dataKey="value" strokeWidth={1} />',
+      '<Line dataKey="value" strokeWidth={3} />',],
     },{
       name: 'layout',
       type: '\'horizontal\' | \'vertical\'',


### PR DESCRIPTION
Hi, I found a typo in the API documentation for the Line component.
The format for strokeWidth prop should be number instead of array.

Fixed the typo from:
`format: ['[{x: 12, y: 12, value: 240}]'],`
to
`format: ['<Line dataKey="value" strokeWidth={1} />',
      '<Line dataKey="value" strokeWidth={3} />',],`
