### PR TITLE
Fix: Add documentation and example for 'segment' prop in ReferenceLine

### DIFF
--- a/src/docs/api/ReferenceLine.js
+++ b/src/docs/api/ReferenceLine.js
@@ -114,6 +114,16 @@ export default {
         'zh-CN': '虚线的宽度',
       },
     },
+    {
+      name: 'segment',
+      type: 'Array',
+      defaultVal: undefined,
+      isOptional: true,
+      desc: {
+        'en-US': 'Array of endpoints in { x, y } format. These endpoints would be used to draw the ReferenceLine.',
+        'zh-CN': '{x，y}格式的端点数组。这些端点将用于绘制参考线。',
+      },
+    },
   ],
   parentComponents: [
     'AreaChart', 'BarChart', 'LineChart', 'ComposedChart',

--- a/src/docs/apiExamples/ReferenceLine.js
+++ b/src/docs/apiExamples/ReferenceLine.js
@@ -42,6 +42,7 @@ const example = () => (
     <Tooltip />
     <ReferenceLine x="Page C" stroke="green" label="Min PAGE" />
     <ReferenceLine y={4000} label="Max" stroke="red" strokeDasharray="3 3" />
+    <ReferenceLine label="Segment" stroke="green" strokeDasharray="3 3" segment={[{ x: 'Page A', y: 0 }, { x: 'Page C', y: 4000 }]} />
     <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
   </AreaChart>
 );
@@ -55,6 +56,7 @@ const exampleCode = `
     <Tooltip />
     <ReferenceLine x="Page C" stroke="green" label="Min PAGE" />
     <ReferenceLine y={4000} label="Max" stroke="red" strokeDasharray="3 3" />
+    <ReferenceLine label="Segment" stroke="green" strokeDasharray="3 3" segment={[{ x: 'Page A', y: 0 }, { x: 'Page C', y: 4000 }]} />
     <Area type="monotone" dataKey="uv" stroke="#8884d8" fill="#8884d8" />
   </AreaChart>
 `;


### PR DESCRIPTION
Added documentation and example for `segment` prop, as it is part of the code but wasn't part of the documentation.

Please verify the translation from en-US to zh-CN. I have used google translate for it.