### PR TITLE
Fix: Displaying prop tickCount in YAxis

### DIFF
--- a/src/docs/api/YAxis.js
+++ b/src/docs/api/YAxis.js
@@ -73,6 +73,7 @@ export default {
         'en-US': 'The count of axis ticks. Not used if \'type\' is \'category\'.',
         'zh-CN': '刻度数。如果\'type\'是\'category\'，则不使用。',
       },
+    }, {
       name: 'domain',
       type: 'Array',
       defaultVal: '[0, \'auto\']',


### PR DESCRIPTION
Fixing the construction of the object that displays the props of the YAxis component, because due to a small bug, the prop `tickCount` is not being displayed in the documentation.