### PR TITLE
Add doc entry for StrokeDashArray for Line and CartesianGrid

### DIFF
--- a/src/docs/api/CartesianGrid.js
+++ b/src/docs/api/CartesianGrid.js
@@ -73,6 +73,20 @@ export default {
         'en-US': 'The x-coordinates of all vertical lines.',
         'zh-CN': '所有竖直网格线的 x 坐标。',
       },
+    }, {
+      name: 'strokeDashArray',
+      type: 'String',
+      defaultVal: 'null',
+      isOptional: false,
+      desc: {
+        'en-US': 'The pattern of dashes and gaps used to paint the lines of the grid',
+        'zh-CN': 'The pattern of dashes and gaps used to paint the lines of the grid',
+      },
+      format: [
+        '<CartesianGrid strokeDashArray="4" />',
+        '<CartesianGrid strokeDashArray="4 1" />',
+        '<CartesianGrid strokeDashArray="4 1 2" />',
+      ],
     },
   ],
   parentComponents: [

--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -301,6 +301,20 @@ export default {
         'en-US': 'The customized event handler of mouseleave on the area in this group',
         'zh-CN': '曲线 mouseleave 事件的回调函数。',
       },
+    }, {
+      name: 'strokeDashArray',
+      type: 'String',
+      defaultVal: 'null',
+      isOptional: false,
+      desc: {
+        'en-US': 'The pattern of dashes and gaps used to paint the line',
+        'zh-CN': 'The pattern of dashes and gaps used to paint the line',
+      },
+      format: [
+        '<Line strokeDashArray="4" />',
+        '<Line strokeDashArray="4 1" />',
+        '<Line strokeDashArray="4 1 2" />',
+      ],
     },
   ],
   parentComponents: [


### PR DESCRIPTION
Identical to https://github.com/recharts/recharts.org/pull/115 but added an entry to `CartesianGrid` (as well as `Line`)

Addresses https://github.com/recharts/recharts/issues/2094

This needs translation to Chinese language.