### PR TITLE
Added angle prop to XAxis API

### DIFF
--- a/src/docs/api/XAxis.js
+++ b/src/docs/api/XAxis.js
@@ -92,6 +92,15 @@ export default {
         'zh-CN': '是否允许类目轴有重复的类目。',
       },
     }, {
+      name: 'angle',
+      type: 'Number',
+      defaultVal: '0',
+      isOptional: false,
+      desc: {
+        'en-US': 'The angle of axis ticks.',
+        'zh-CN': '轴刻度的角度。',
+      },
+    }, {
       name: 'tickCount',
       type: 'Number',
       defaultVal: '5',


### PR DESCRIPTION
The `angel` prop is missing in XAxis API documentation.  
    
XAxis API documentation : [Link](https://recharts.org/en-US/api/XAxis)    

---
### **Before** 
![image](https://user-images.githubusercontent.com/54893898/99503993-42709200-29c2-11eb-8e4d-53b6733e8612.png)

---
### **After**   
![image](https://user-images.githubusercontent.com/54893898/99504053-54eacb80-29c2-11eb-9f34-1cab069019db.png)
