### PR TITLE
Add position field to tooltip.js doc

### DIFF
--- a/src/docs/api/Tooltip.js
+++ b/src/docs/api/Tooltip.js
@@ -156,6 +156,17 @@ export default {
       },
     },
     {
+      name: 'position',
+      type: 'Object',
+      defaultVal: 'null',
+      isOptional: true,
+      desc: {
+        'en-US': 'If this field is set, the tooltip position will be fixed and will not move anymore.',
+        'zh-CN': '如果设置了此字段，则工具提示位置将固定不变，并且将不再移动。',
+      },
+      format: ['{ x: 100, y: 140 }'],
+    },
+    {
       name: 'coordinate',
       type: 'Object',
       defaultVal: '{ x: 0, y: 0 }',


### PR DESCRIPTION
The next PR merged in 2016 show the addition of the position field but was not added to the doc.
https://github.com/recharts/recharts/commit/31d2b2d367adecaef34c5bb0371f27126dc51d8b

I spent 20mins to find it 😅😅
I think it might be useful to many :-) 

I did the chinese translation on google translate, improve it if not accurate please