### PR TITLE
Update Docs Pages Content Paddings so docs are legible

### DIFF
--- a/src/styles/container.scss
+++ b/src/styles/container.scss
@@ -123,7 +123,7 @@ footer {
 
   > .content {
     min-width: 1200px;
-    padding-left: 260px;
+    padding-left: 300px;
 
     .page-title {
       padding-top: 30px;


### PR DESCRIPTION
Updates left padding so that docs are legible.

Before:
![image](https://user-images.githubusercontent.com/4666313/111560596-2e1e8500-8769-11eb-8027-59968d530772.png)

After:
![image](https://user-images.githubusercontent.com/4666313/111560636-4098be80-8769-11eb-9f16-5fee9c85c787.png)
