### PR TITLE
fix: Update codesandbox link to LineChartHasMultiSeries

### DIFF
--- a/docs/examples/LineChart/LineChartHasMultiSeries.js
+++ b/docs/examples/LineChart/LineChartHasMultiSeries.js
@@ -29,7 +29,7 @@ const series = [
 ];
 
 export default class Example extends PureComponent {
-  static demoUrl = 'https://codesandbox.io/s/line-chart-with-customized-label-hs5b7';
+  static demoUrl = 'https://codesandbox.io/s/line-chart-width-multi-series-64tbt';
 
   render() {
     return (

--- a/src/docs/api/Area.js
+++ b/src/docs/api/Area.js
@@ -56,7 +56,7 @@ export default {
     {
       name: 'legendType',
       type:
-        "'line' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+        "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'line'",
       isOptional: true,
       desc: {

--- a/src/docs/api/Bar.js
+++ b/src/docs/api/Bar.js
@@ -44,7 +44,7 @@ export default {
     {
       name: 'legendType',
       type:
-        "'line' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+        "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'rect'",
       isOptional: true,
       desc: {

--- a/src/docs/api/Funnel.js
+++ b/src/docs/api/Funnel.js
@@ -35,7 +35,7 @@ export default {
     {
       name: 'legendType',
       type:
-        "'line' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'line'",
       isOptional: true,
       desc: {

--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -57,7 +57,7 @@ export default {
     {
       name: 'legendType',
       type:
-        "'line' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'line'",
       isOptional: true,
       desc: {

--- a/src/docs/api/Pie.js
+++ b/src/docs/api/Pie.js
@@ -127,7 +127,7 @@ export default {
     {
       name: 'legendType',
       type:
-        "'line' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'rect'",
       isOptional: false,
       desc: {

--- a/src/docs/api/Radar.js
+++ b/src/docs/api/Radar.js
@@ -47,7 +47,7 @@ export default {
     {
       name: 'legendType',
       type:
-        "'line' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'rect'",
       isOptional: true,
       desc: {

--- a/src/docs/api/RadialBar.js
+++ b/src/docs/api/RadialBar.js
@@ -70,7 +70,7 @@ export default {
     {
       name: 'legendType',
       type:
-        "'line' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'rect'",
       isOptional: true,
       desc: {

--- a/src/docs/api/Scatter.js
+++ b/src/docs/api/Scatter.js
@@ -4,7 +4,7 @@ export default {
     {
       name: 'legendType',
       type:
-        "'line' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'circle'",
       isOptional: true,
       desc: {


### PR DESCRIPTION
I also added `plainline` as a legendType which is supported but it's not in the docs yet

This resolves #167 

![image](https://user-images.githubusercontent.com/11246258/115789990-d92ee980-a37a-11eb-9b19-eeed831e4bb0.png)
