### PR TITLE
Put `format` values of Tooltip's `allowEscapeViewBox` as a string

### DIFF
--- a/src/docs/api/Tooltip.js
+++ b/src/docs/api/Tooltip.js
@@ -141,7 +141,7 @@ export default {
         'en-US': 'This option allows the tooltip to extend beyond the viewBox of the chart itself.',
         'zh-CN': '此选项允许工具提示扩展到图表本身的viewBox之外。',
       },
-      format: [{ x: true }, { y: true }, { x: true, y: true }],
+      format: ['{ x: true }', '{ y: true }', '{ x: true, y: true }'],
     },
     {
       name: 'active',


### PR DESCRIPTION
I noticed a small error in the formatting of the Tooltip's `allowEscapeViewBox` example in the docs:

![image](https://user-images.githubusercontent.com/2098462/120997536-950b7300-c787-11eb-8403-a967f0e41b6b.png)
