### PR TITLE
fix: install button version to v2.1.9

### DIFF
--- a/src/views/IndexView.js
+++ b/src/views/IndexView.js
@@ -68,7 +68,7 @@ class IndexView extends PureComponent {
           <p>
             <Link to={`/${locale}/guide/installation`} className="button install-btn">
               <i className="icon-energy" />
-              {localeGet(locale, 'home', 'install')} v2.1.5
+              {localeGet(locale, 'home', 'install')} v2.1.8
             </Link>
           </p>
           <iframe

--- a/src/views/IndexView.js
+++ b/src/views/IndexView.js
@@ -68,7 +68,7 @@ class IndexView extends PureComponent {
           <p>
             <Link to={`/${locale}/guide/installation`} className="button install-btn">
               <i className="icon-energy" />
-              {localeGet(locale, 'home', 'install')} v2.1.8
+              {localeGet(locale, 'home', 'install')} v2.1.9
             </Link>
           </p>
           <iframe


### PR DESCRIPTION
Fixed the version of the install button to the latest version of Recharts.
The latest version is v2.1.9.