### PR TITLE
fix wrong prop naming

### DIFF
--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -56,8 +56,7 @@ export default {
     },
     {
       name: 'legendType',
-      type:
-      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+      type: "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'line'",
       isOptional: true,
       desc: {
@@ -356,7 +355,7 @@ export default {
       },
     },
     {
-      name: 'strokeDashArray',
+      name: 'strokeDasharray',
       type: 'String',
       defaultVal: 'null',
       isOptional: false,
@@ -364,7 +363,7 @@ export default {
         'en-US': 'The pattern of dashes and gaps used to paint the line',
         'zh-CN': 'The pattern of dashes and gaps used to paint the line',
       },
-      format: ['<Line strokeDashArray="4" />', '<Line strokeDashArray="4 1" />', '<Line strokeDashArray="4 1 2" />'],
+      format: ['<Line strokeDasharray="4" />', '<Line strokeDasharray="4 1" />', '<Line strokeDasharray="4 1 2" />'],
     },
   ],
   parentComponents: ['LineChart', 'ComposedChart'],


### PR DESCRIPTION
- Fixes the strokeDasharray prop naming added on [#144](https://github.com/recharts/recharts.org/pull/144)