### PR TITLE
Update example link for stackOffset param

### DIFF
--- a/src/docs/api/BarChart.js
+++ b/src/docs/api/BarChart.js
@@ -136,7 +136,7 @@ export default {
       examples: [
         {
           name: 'A barChart stacked by sign of value',
-          value: '/examples/#BarChartStackedBySign',
+          value: '/examples/BarChartStackedBySign',
         },
         {
           name: 'D3 stackOffset',


### PR DESCRIPTION
The link for the example [A barChart stacked by sign of value](https://recharts.org/en-USundefined) in the `stackOffset` param of the BarChart in the docs is not working. 

Removing the `#` from the target url route should fix the issue.