### PR TITLE
Fix typo in SimpleRadialBarChart example: unknow -> unknown

### DIFF
--- a/docs/examples/RadialBarChart/SimpleRadialBarChart.js
+++ b/docs/examples/RadialBarChart/SimpleRadialBarChart.js
@@ -39,7 +39,7 @@ const data = [
     fill: '#d0ed57',
   },
   {
-    name: 'unknow',
+    name: 'unknown',
     uv: 6.67,
     pv: 4800,
     fill: '#ffc658',


### PR DESCRIPTION
Fixing a typo in the SimpleRadialBarChart example: 'unknow' should be 'unknown'.