### PR TITLE
docs: add API documentation for includeHidden axis prop

### DIFF
--- a/src/docs/api/XAxis.js
+++ b/src/docs/api/XAxis.js
@@ -159,7 +159,7 @@ export default {
         'en-US':
           "Ensures that all datapoints within a chart contribute to its domain calculation, even when they are hidden",
         'zh-CN':
-          '',
+          '确保图表中的所有数据点都有助于其域计算，即使它们被隐藏时也是如此',
       },
       format: [
         "<XAxis type=\"number\" includeHidden />",

--- a/src/docs/api/XAxis.js
+++ b/src/docs/api/XAxis.js
@@ -151,6 +151,21 @@ export default {
       ],
     },
     {
+      name: 'includeHidden',
+      type: 'Boolean',
+      defaultVal: "false",
+      isOptional: true,
+      desc: {
+        'en-US':
+          "Ensures that all datapoints within a chart contribute to its domain calculation, even when they are hidden",
+        'zh-CN':
+          '',
+      },
+      format: [
+        "<XAxis type=\"number\" includeHidden />",
+      ],
+    },
+    {
       name: 'interval',
       type: '"preserveStart" | "preserveEnd" | "preserveStartEnd" | Number',
       defaultVal: "'preserveEnd'",

--- a/src/docs/api/YAxis.js
+++ b/src/docs/api/YAxis.js
@@ -109,6 +109,21 @@ export default {
       ],
     },
     {
+      name: 'includeHidden',
+      type: 'Boolean',
+      defaultVal: "false",
+      isOptional: true,
+      desc: {
+        'en-US':
+          "Ensures that all datapoints within a chart contribute to its domain calculation, even when they are hidden",
+        'zh-CN':
+          '',
+      },
+      format: [
+        "<YAxis type=\"number\" includeHidden />",
+      ],
+    },
+    {
       name: 'interval',
       type: '"preserveStart" | "preserveEnd" | "preserveStartEnd" | Number',
       defaultVal: "'preserveEnd'",

--- a/src/docs/api/YAxis.js
+++ b/src/docs/api/YAxis.js
@@ -117,7 +117,7 @@ export default {
         'en-US':
           "Ensures that all datapoints within a chart contribute to its domain calculation, even when they are hidden",
         'zh-CN':
-          '',
+          '确保图表中的所有数据点都有助于其域计算，即使它们被隐藏时也是如此',
       },
       format: [
         "<YAxis type=\"number\" includeHidden />",


### PR DESCRIPTION
Addresses https://github.com/recharts/recharts/issues/3099, https://github.com/recharts/recharts/pull/3103

Adds API documentation for the `includeHidden` axis prop introduced in https://github.com/recharts/recharts/pull/3103. Having seen a contributor do the same in another PR, I've used Google Translate for the Chinese description. More than happy for this to be replaced by a better translation from a native speaker.