### PR TITLE
Add doc for reversed prop of PolarRadiusAxis

### DIFF
--- a/src/docs/api/PolarRadiusAxis.js
+++ b/src/docs/api/PolarRadiusAxis.js
@@ -70,6 +70,16 @@ export default {
       ],
     },
     {
+      name: 'reversed',
+      type: 'Boolean',
+      defaultVal: 'false',
+      isOptional: true,
+      desc: {
+        'en-US': 'If set to true, the ticks of this axis are reversed.',
+        'zh-CN': '是否反转刻度的顺序',
+      },
+    },
+    {
       name: 'label',
       type: 'String | Number | ReactElement | Function',
       defaultVal: 'null',


### PR DESCRIPTION
Related issue: https://github.com/recharts/recharts/issues/2966
Related PR: https://github.com/recharts/recharts/pull/3123

This adds the missing docs for the `reversed` props of the PolarRadiusAxis component