### PR TITLE
chore: prettierignore, eslint ignore paths, run autofix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
   },
   "parser": "babel-eslint",
   "plugins": ["react"],
+  "ignorePatterns": ["src/docs/**/*.js"],
   "ecmaFeatures": {
     "classes": true,
     "jsx": true,

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/docs

--- a/src/views/IndexView.js
+++ b/src/views/IndexView.js
@@ -68,7 +68,8 @@ class IndexView extends PureComponent {
           <p>
             <Link to={`/${locale}/guide/installation`} className="button install-btn">
               <i className="icon-energy" />
-              {localeGet(locale, 'home', 'install')}&nbsp;v2.2.0
+              {localeGet(locale, 'home', 'install')}
+              &nbsp;v2.2.0
             </Link>
           </p>
           <iframe


### PR DESCRIPTION
Runs `npm run autofix` to fix inconsistent formatting

* add prettierignore to ignore docs folder
* add eslint ignorePaths to ignore docs folder