### PR TITLE
fix: display example and code editor horizontally in 1300px screen

### DIFF
--- a/src/views/ExampleView.scss
+++ b/src/views/ExampleView.scss
@@ -13,7 +13,7 @@
       border: 1px solid #f5f5f5;
     }
 
-    @media screen and (max-width: 1400px) {
+    @media screen and (max-width: 1300px) {
       .example-inner-wrapper {
         flex-direction: column;
 
@@ -48,7 +48,7 @@
     }
 
     .monaco-editor-wrapper {
-      width: 800px;
+      width: 720px;
       height: 100%;
 
       .monaco-editor-toolbar {


### PR DESCRIPTION
### Description

By default resolution in small screens around 1380px(MacBook (13-inch) with sidebar), the example and code editor display vertically.
<img width="1378" alt="image" src="https://user-images.githubusercontent.com/43896664/213918297-673b9ff0-dcc0-42f7-ae73-3b86a88d2e3d.png">

Changed to:
<img width="1376" alt="image" src="https://user-images.githubusercontent.com/43896664/213918328-2f0b3763-aaba-42c4-a123-626487fd073f.png">
