### PR TITLE
feat: embed storybook in current docs repo

### DIFF
--- a/src/layouts/Frame.js
+++ b/src/layouts/Frame.js
@@ -7,7 +7,7 @@ import { getLocaleType, localeGet } from '../utils/LocaleUtils';
 import Affix from '../components/Affix';
 import '../styles/app.scss';
 
-const modules = ['guide', 'api', 'examples', 'blog'];
+const modules = ['guide', 'api', 'examples', 'blog', 'storybook'];
 
 const locales = [
   { locale: 'en-US', text: 'En' },

--- a/src/locale/en-US.js
+++ b/src/locale/en-US.js
@@ -34,6 +34,7 @@ const map = {
     api: 'API',
     examples: 'Examples',
     blog: 'Blog',
+    storybook: 'Storybook (WIP)',
     contract: 'Contact us by',
   },
   guide: {

--- a/src/locale/zh-CN.js
+++ b/src/locale/zh-CN.js
@@ -34,6 +34,7 @@ const map = {
     api: 'API',
     examples: '示例',
     blog: '博客',
+    storybook: 'Storybook (WIP)',
     contract: '联系我们',
   },
   guide: {

--- a/src/locale/zh-CN.js
+++ b/src/locale/zh-CN.js
@@ -34,7 +34,7 @@ const map = {
     api: 'API',
     examples: '示例',
     blog: '博客',
-    storybook: 'Storybook (WIP)',
+    storybook: 'Storybook (工作正在进行中)',
     contract: '联系我们',
   },
   guide: {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { Route, IndexRoute, Redirect, IndexRedirect } from 'react-router';
 import _ from 'lodash';
-import { IndexView, GuideView, APIView, ExamplesView, BlogView } from '../views';
+import { IndexView, GuideView, APIView, ExamplesView, BlogView, Storybook } from '../views';
 import Frame from '../layouts/Frame';
 import Locale from '../locale';
 
@@ -35,6 +35,7 @@ export default (store) => (
     <Route path="/*/api(/:name)" component={APIView} />
     <Route path="/*/examples(/:name)" component={ExamplesView} />
     <Route path="/*/blog" component={BlogView} />
+    <Route path="/*/storybook" component={Storybook} />
     <Route path="*" component={IndexView} />
   </Route>
 );

--- a/src/views/IndexView.js
+++ b/src/views/IndexView.js
@@ -75,8 +75,6 @@ class IndexView extends PureComponent {
           <iframe
             title="star"
             src="https://ghbtns.com/github-btn.html?user=recharts&repo=recharts&type=star&count=true&size=median"
-            frameBorder="0"
-            scrolling="0"
             width="120px"
             height="22px"
           />

--- a/src/views/Storybook.js
+++ b/src/views/Storybook.js
@@ -1,0 +1,22 @@
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import './Storybook.scss';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const modules = ['installation', 'getting-started', 'customize'];
+
+@connect((state, ownProps) => {
+  const pathname = ownProps.location.pathname || '';
+  const paths = pathname.split('/');
+
+  return {
+    page: paths && paths.length === 4 ? paths[3] : modules[0],
+  };
+})
+class Storybook extends PureComponent {
+  render() {
+    return <iframe className='storybook' src="https://master--63da8268a0da9970db6992aa.chromatic.com/" />;
+  }
+}
+
+export default Storybook;

--- a/src/views/Storybook.js
+++ b/src/views/Storybook.js
@@ -2,20 +2,17 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import './Storybook.scss';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const modules = ['installation', 'getting-started', 'customize'];
-
 @connect((state, ownProps) => {
   const pathname = ownProps.location.pathname || '';
   const paths = pathname.split('/');
 
   return {
-    page: paths && paths.length === 4 ? paths[3] : modules[0],
+    page: paths && paths.length && paths[paths.length - 1],
   };
 })
 class Storybook extends PureComponent {
   render() {
-    return <iframe className='storybook' src="https://master--63da8268a0da9970db6992aa.chromatic.com/" />;
+    return <iframe className="storybook" src="https://master--63da8268a0da9970db6992aa.chromatic.com/" />;
   }
 }
 

--- a/src/views/Storybook.scss
+++ b/src/views/Storybook.scss
@@ -1,0 +1,4 @@
+iframe.storybook {
+  width: 100%;
+  height: calc(100vh - 150px);
+}

--- a/src/views/Storybook.scss
+++ b/src/views/Storybook.scss
@@ -1,4 +1,6 @@
 iframe.storybook {
   width: 100%;
   height: calc(100vh - 150px);
+  border: 0;
+  overflow: hidden;
 }

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -3,5 +3,6 @@ import GuideView from './GuideView';
 import APIView from './APIView';
 import ExamplesView from './ExamplesView';
 import BlogView from './BlogView';
+import Storybook from './Storybook';
 
-export { IndexView, GuideView, APIView, ExamplesView, BlogView };
+export { IndexView, GuideView, APIView, ExamplesView, BlogView, Storybook };


### PR DESCRIPTION
From https://github.com/recharts/recharts/pull/3297 and as an initial step, integrate the storybook with the current docs repo before making more organizational changes in recharts repo

* Add iframe
* Add storybook component and required imports

![image](https://user-images.githubusercontent.com/25180830/217085986-c837d457-ad58-42fd-bc5b-fdbb4bbd6241.png)
