### PR TITLE
used Date() for year, also want to raise issue

### DIFF
--- a/src/layouts/Frame.js
+++ b/src/layouts/Frame.js
@@ -98,7 +98,7 @@ class Frame extends Component {
               MIT License
             </a>
           </p>
-          <p>Copyright (c) 2016-2021 Recharts Group</p>
+          <p>Copyright (c) 2016-{new Date().getFullYear()} Recharts Group</p>
         </footer>
       </div>
     );


### PR DESCRIPTION
Hi,

This PR updates the Copyright year footer using `Date()` and removes the hard-coding of the year for every new year.

P.S.  I am also raising an issue regarding the website, it is not related to this PR.