### PR TITLE
fix: broken example url reference & code display

### DIFF
--- a/src/docs/api/BarChart.js
+++ b/src/docs/api/BarChart.js
@@ -146,7 +146,7 @@ export default {
       examples: [
         {
           name: 'A barChart stacked by sign of value',
-          value: '/examples/BarChartStackedBySign',
+          url: '/examples/BarChartStackedBySign',
         },
         {
           name: 'D3 stackOffset',

--- a/src/docs/apiExamples/BarChart.js
+++ b/src/docs/apiExamples/BarChart.js
@@ -94,6 +94,15 @@ const rangeExample = () => (
   </BarChart>
 );
 
+const rangeExampleCode = `
+<BarChart width={730} height={250} data={rangeData} margin={{top: 20, right: 20, bottom: 20, left: 20}} >
+  <XAxis dataKey="day" />
+  <YAxis />
+  <Tooltip />
+  <Bar dataKey="temperature" fill="#8884d8" />
+</BarChart>
+`
+
 export default [
   {
     demo: example,
@@ -102,5 +111,7 @@ export default [
   },
   {
     demo: rangeExample,
+    code: rangeExampleCode,
+    dataCode: `const data = ${JSON.stringify(rangeData, null, 2)}`
   },
 ];


### PR DESCRIPTION
1. Add code example  for ed6a0f3da8321f49726522db3931c34a0f512a51.
![code_exp](https://user-images.githubusercontent.com/11475482/218918279-464bd882-988f-482d-a2ea-fcb0f3c63ac2.png)

2. Set correct `href` for example [A barChart stacked by sign of value](https://recharts.org/en-US/examples/BarChartStackedBySign) in prop [stackOffset](https://recharts.org/en-US/api/BarChart#stackOffset).
![url](https://user-images.githubusercontent.com/11475482/218917306-8b8e9f84-a2cd-45ea-888b-263d91d59f7b.png)
