### PR TITLE
fix: needle not showing in Firefox in the PieChartWithNeedle example

### DIFF
--- a/src/docs/exampleComponents/PieChart/PieChartWithNeedle.js
+++ b/src/docs/exampleComponents/PieChart/PieChartWithNeedle.js
@@ -35,7 +35,7 @@ const needle = (value, data, cx, cy, iR, oR, color) => {
 
   return [
     <circle cx={x0} cy={y0} r={r} fill={color} stroke="none" />,
-    <path d={`M${xba},${yba}L${xbb},${ybb},L${xp},${yp},L${xba},${yba}`} stroke="#none" fill={color} />,
+    <path d={`M${xba} ${yba}L${xbb} ${ybb} L${xp} ${yp} L${xba} ${yba}`} stroke="#none" fill={color} />,
   ];
 };
 


### PR DESCRIPTION
The `PieChartWithNeedle` example is broken on Firefox:

![image](https://user-images.githubusercontent.com/68925286/219189300-12f481c0-7146-42f8-953f-69c4a748a370.png)

And here's how it looks with my changes (I tested on both Firefox and chrome)

![image](https://user-images.githubusercontent.com/68925286/219191288-2d83716e-79b8-4c32-aab9-e024899dfd15.png)

Found the solution here: https://support.mozilla.org/bm/questions/1254200