### PR TITLE
add d3-shape to scope of example code runner

### DIFF
--- a/src/views/ExamplesView.js
+++ b/src/views/ExamplesView.js
@@ -9,6 +9,7 @@ import MonacoEditor from 'react-monaco-editor/lib';
 import { Runner } from 'react-runner';
 import * as ReactScope from 'react';
 import * as RechartsScope from 'recharts';
+import * as D3ShapeScope from 'd3-shape';
 import Examples from '../docs/exampleComponents';
 import { getLocaleType } from '../utils/LocaleUtils';
 import './ExampleView.scss';
@@ -203,6 +204,7 @@ class ExamplesView extends PureComponent {
       import: {
         react: ReactScope,
         recharts: RechartsScope,
+        ['d3-shape']: D3ShapeScope,
       },
     };
 


### PR DESCRIPTION
Fixes the first of #254 

The `CardiinalAreaChart` example was not working, since it imported from `d3-shape` which was not in the scope of the runner.