### PR TITLE
fix: Incorrect PORT number in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This site is built with react and redux. Pull requests welcome!
 
 ## Developing
 
-Start a dev server at localhost:8787:
+Start a dev server at localhost:4000:
 
 ```
 $ npm install


### PR DESCRIPTION
The **PORT** number for the dev server mentioned in Readme is "**localhost:8787**", which is incorrect.

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/78548130/226143958-afd0b314-ed01-4204-9784-70d481af7bd8.png">

Actually, it runs on "**localhost:4000**"

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/78548130/226143950-374e7c4c-e271-4308-85ae-6d4ec297f0c3.png">
