### PR TITLE
Add docs for `stroke` prop in `<Line />`

### DIFF
--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -160,6 +160,17 @@ export default {
       format: ['[{x: 12, y: 12, value: 240}]'],
     },
     {
+      name: 'stroke',
+      type: 'String',
+      defaultVal: '#3182bd',
+      isOptional: true,
+      desc: {
+        'en-US': 'The color of the stroke',
+        'zh-CN': '描边的颜色',
+      },
+      format: ['<Line dataKey="value" stroke="#ff0ff0" />'],
+    },
+    {
       name: 'strokeWidth',
       type: 'String | Number',
       defaultVal: '1',


### PR DESCRIPTION
- `zh-CN` text translated with Google Translate.
- The default value is taken from:

https://github.com/recharts/recharts/blob/5fc03941c8c667f2db60a39a21a7f1807dad8d9e/src/cartesian/Line.tsx#L91