### PR TITLE
feat(Sankey): Add documentation for the `sort` Sankey prop

### DIFF
--- a/src/docs/api/SankeyChart.js
+++ b/src/docs/api/SankeyChart.js
@@ -62,6 +62,15 @@ export default {
       ],
     },
     {
+      name: 'sort',
+      type: 'Boolean',
+      defaultVal: 'true',
+      isOptional: true,
+      desc: {
+        'en-US': 'Whether to sort the nodes on th y axis, or to display them as user-defined.',
+      },
+    },
+    {
       name: 'nodePadding',
       type: 'Number',
       defaultVal: '10',


### PR DESCRIPTION
This updates the docs to reflect the changes proposed in https://github.com/recharts/recharts/pull/3690

In a nutshell, this is about adding a `sort` prop to the `Sankey` component to allow the user to choose between sorting (default) and not sorting the nodes (with the prop set to `false`)