### PR TITLE
feat: define html lang and allow mobile zoom

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>Recharts</title>
   <meta charset="utf-8">
   <meta name="description" content="Recharts - Re-designed charting library built with React and D3.">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2">
   <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600|Roboto Mono|Oswald:300' rel='stylesheet' type='text/css'>
 </head>
 <body>


### PR DESCRIPTION
Defining the language in the HTML element and allow mobile zoom.

## Description

I am defining the `lang` attribute on the `html` element so that the default language will be set for screen reader users. You can see why this is important on deque: [<html> element must have a lang attribute](https://dequeuniversity.com/rules/axe/4.8/html-has-lang?application=AxeChrome)

I have also enabled zooming on mobile devices by removing `user-scalable="no"` and ensuring `maximum-scale` is not less than 2. This is important for users with low vision who rely on screen magnification to view the page.
[Zooming and scaling must not be disabled](https://dequeuniversity.com/rules/axe/4.8/meta-viewport?application=axe-linter)

## Related Issue

https://github.com/recharts/recharts/issues/3874

## Motivation and Context

I am an Accessibility Engineer, and I want to improve accessibility where I can. I use your tools a lot and really appreciate them.

## How Has This Been Tested?

I followed the build instructions and verified that my change fixed the linked issues.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added a storybook story or extended an existing story to show my changes
- [x] All new and existing tests passed.
