### PR TITLE
chore: Bump recharts version to 2.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "react-router-redux": "~4.0.7",
         "react-router-scroll": "~0.4.1",
         "react-runner": "^1.0.3",
-        "recharts": "^2.9.0",
+        "recharts": "^2.10.0",
         "redux": "4.0.0",
         "redux-thunk": "^2.3.0",
         "rimraf": "^2.5.4",
@@ -3653,6 +3653,14 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
       "engines": {
         "node": ">=6"
       }
@@ -9168,18 +9176,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
-    "node_modules/react-resize-detector": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.0.4.tgz",
-      "integrity": "sha512-ln9pMAob8y8mc9UI4aZuuWFiyMqBjnTs/sxe9Vs9dPXUjwCTeKK1FP8I75ufnb/2mEEZXG6wOo/fjMcBRRuAXw==",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-router": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-3.2.6.tgz",
@@ -9311,22 +9307,21 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.9.0.tgz",
-      "integrity": "sha512-cVgiAU3W5UrA8nRRV/N0JrudgZzY/vjkzrlShbH+EFo1vs4nMlXgshZWLI0DfDLmn4/p4pF7Lq7F5PU+K94Ipg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.10.0.tgz",
+      "integrity": "sha512-ItfXIVD5zW9RnYq1bRGZdMy1Ssuh0pd9GhnNm354dRK4ovB9zfIw/jlTz7UHUSnFZI6n9tLG8EfN1iKukeFa8A==",
       "dependencies": {
-        "classnames": "^2.2.5",
+        "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.19",
         "react-is": "^16.10.2",
-        "react-resize-detector": "^8.0.4",
-        "react-smooth": "^2.0.4",
+        "react-smooth": "^2.0.5",
         "recharts-scale": "^0.4.4",
         "tiny-invariant": "^1.3.1",
         "victory-vendor": "^36.6.8"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "peerDependencies": {
         "prop-types": "^15.6.0",
@@ -14665,6 +14660,11 @@
         "shallow-clone": "^3.0.0"
       }
     },
+    "clsx": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -18815,14 +18815,6 @@
         }
       }
     },
-    "react-resize-detector": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.0.4.tgz",
-      "integrity": "sha512-ln9pMAob8y8mc9UI4aZuuWFiyMqBjnTs/sxe9Vs9dPXUjwCTeKK1FP8I75ufnb/2mEEZXG6wOo/fjMcBRRuAXw==",
-      "requires": {
-        "lodash": "^4.17.21"
-      }
-    },
     "react-router": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-3.2.6.tgz",
@@ -18929,16 +18921,15 @@
       }
     },
     "recharts": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.9.0.tgz",
-      "integrity": "sha512-cVgiAU3W5UrA8nRRV/N0JrudgZzY/vjkzrlShbH+EFo1vs4nMlXgshZWLI0DfDLmn4/p4pF7Lq7F5PU+K94Ipg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.10.0.tgz",
+      "integrity": "sha512-ItfXIVD5zW9RnYq1bRGZdMy1Ssuh0pd9GhnNm354dRK4ovB9zfIw/jlTz7UHUSnFZI6n9tLG8EfN1iKukeFa8A==",
       "requires": {
-        "classnames": "^2.2.5",
+        "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.19",
         "react-is": "^16.10.2",
-        "react-resize-detector": "^8.0.4",
-        "react-smooth": "^2.0.4",
+        "react-smooth": "^2.0.5",
         "recharts-scale": "^0.4.4",
         "tiny-invariant": "^1.3.1",
         "victory-vendor": "^36.6.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "react-router-redux": "~4.0.7",
         "react-router-scroll": "~0.4.1",
         "react-runner": "^1.0.3",
-        "recharts": "^2.10.0",
+        "recharts": "^2.10.1",
         "redux": "4.0.0",
         "redux-thunk": "^2.3.0",
         "rimraf": "^2.5.4",
@@ -9307,9 +9307,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.10.0.tgz",
-      "integrity": "sha512-ItfXIVD5zW9RnYq1bRGZdMy1Ssuh0pd9GhnNm354dRK4ovB9zfIw/jlTz7UHUSnFZI6n9tLG8EfN1iKukeFa8A==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.10.1.tgz",
+      "integrity": "sha512-9bi0jIzxOTfEda+oYqgimKuYfApmBr0zKnAX8r4Iw56k3Saz/IQyBD4zohZL0eyzfz0oGFRH7alpJBgH1eC57g==",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
@@ -18921,9 +18921,9 @@
       }
     },
     "recharts": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.10.0.tgz",
-      "integrity": "sha512-ItfXIVD5zW9RnYq1bRGZdMy1Ssuh0pd9GhnNm354dRK4ovB9zfIw/jlTz7UHUSnFZI6n9tLG8EfN1iKukeFa8A==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.10.1.tgz",
+      "integrity": "sha512-9bi0jIzxOTfEda+oYqgimKuYfApmBr0zKnAX8r4Iw56k3Saz/IQyBD4zohZL0eyzfz0oGFRH7alpJBgH1eC57g==",
       "requires": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-router-redux": "~4.0.7",
     "react-router-scroll": "~0.4.1",
     "react-runner": "^1.0.3",
-    "recharts": "^2.9.0",
+    "recharts": "^2.10.0",
     "redux": "4.0.0",
     "redux-thunk": "^2.3.0",
     "rimraf": "^2.5.4",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-router-redux": "~4.0.7",
     "react-router-scroll": "~0.4.1",
     "react-runner": "^1.0.3",
-    "recharts": "^2.10.0",
+    "recharts": "^2.10.1",
     "redux": "4.0.0",
     "redux-thunk": "^2.3.0",
     "rimraf": "^2.5.4",


### PR DESCRIPTION
Noticed the recharts.org site is out of sync with the newly released 2.10.0 package.

Version strings on the site are derived from package.json so just bumped there, did a quick test locally and all seems to be well.