### PR TITLE
Read Recharts version from npm

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Build with npm
-        run: npm run build
+        run: RECHARTS_LATEST_VERSION=`curl -X GET "https://registry.npmjs.org/recharts/latest" | jq --raw-output '.version'` npm run build
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/src/views/IndexView.js
+++ b/src/views/IndexView.js
@@ -6,7 +6,6 @@ import { getLocaleType, localeGet } from '../utils/LocaleUtils';
 import './IndexView.scss';
 import 'simple-line-icons/scss/simple-line-icons.scss';
 import users from '../docs/users/users';
-import rechartsPackageJson from 'recharts/package.json';
 
 const data = [
   {
@@ -69,8 +68,9 @@ class IndexView extends PureComponent {
           <p>
             <Link to={`/${locale}/guide/installation`} className="button install-btn">
               <i className="icon-energy" />
+              &nbsp;
               {localeGet(locale, 'home', 'install')}
-              &nbsp;v{rechartsPackageJson.version}
+              {process.env.RECHARTS_LATEST_VERSION ? ` v${process.env.RECHARTS_LATEST_VERSION}` : undefined}
             </Link>
           </p>
           <iframe

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -77,7 +77,10 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': JSON.stringify('production'),
+      'process.env': {
+        NODE_ENV: JSON.stringify('production'),
+        RECHARTS_LATEST_VERSION: JSON.stringify(process.env.RECHARTS_LATEST_VERSION),
+      },
       __DEV__: false,
       __DEVTOOLS__: false,
     }),


### PR DESCRIPTION
We used to read the latest version of Recharts available from `recharts/package.json` directly, but it meant we had to update Recharts every time we were releasing a new version.

Starting from now, we'll just need to trigger a new deployment of the website manually and as part of the build process, we fetch the latest version available for Recharts from npm API.

I also took the liberty to change the padding a little bit between the icon and the text:

| Before | After |
| - | - |
| <img width="649" alt="Screenshot 2023-11-27 at 2 03 13 PM" src="https://github.com/recharts/recharts.org/assets/7189823/7d944ca9-5d05-400b-8bc2-19c3fc53e754"> | <img width="628" alt="Screenshot 2023-11-27 at 2 03 06 PM" src="https://github.com/recharts/recharts.org/assets/7189823/6b8b9341-ac49-45de-b9bc-138043c18f2a"> |