### PR TITLE
Banded Chart example

### DIFF
--- a/src/docs/exampleComponents/ComposedChart/BandedChart.js
+++ b/src/docs/exampleComponents/ComposedChart/BandedChart.js
@@ -7,6 +7,8 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
+  Legend,
+  DefaultLegendContent,
   ResponsiveContainer,
 } from 'recharts';
 
@@ -47,6 +49,11 @@ const data = [
         return <Tooltip payload={newPayload} {...rest} />;
     }
 
+    renderLegendWithoutRange = ({ payload, content, ...rest }) => {
+      const newPayload = payload.filter((x) => x.dataKey !== "a");
+      return <DefaultLegendContent payload={newPayload} {...rest} />;
+    }
+
     render() {
         return (
           <ResponsiveContainer width="100%" height="100%">
@@ -61,20 +68,21 @@ const data = [
                 bottom: 0,
             }}
             >
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="name" />
-            <YAxis />
-            <Tooltip content={this.renderTooltipWithoutRange} />
-            <Area
-                type="monotone"
-                dataKey="a"
-                stroke="none"
-                fill="#cccccc"
-                connectNulls
-                dot={false}
-                activeDot={false}
-            />
-            <Line type="natural" dataKey="b" stroke="#ff00ff" connectNulls />
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip content={this.renderTooltipWithoutRange} />
+              <Area
+                  type="monotone"
+                  dataKey="a"
+                  stroke="none"
+                  fill="#cccccc"
+                  connectNulls
+                  dot={false}
+                  activeDot={false}
+              />
+              <Line type="natural" dataKey="b" stroke="#ff00ff" connectNulls />
+              <Legend content={this.renderLegendWithoutRange} />
             </ComposedChart>
           </ResponsiveContainer>
         );

--- a/src/docs/exampleComponents/ComposedChart/BandedChart.js
+++ b/src/docs/exampleComponents/ComposedChart/BandedChart.js
@@ -43,7 +43,7 @@ const data = [
   },
 ];
   
-export function Example() {
+export default function Example() {
   const renderTooltipWithoutRange = ({ payload, content, ...rest }) => {
       const newPayload = payload.filter((x) => x.dataKey !== "a");
       return <Tooltip payload={newPayload} {...rest} />;

--- a/src/docs/exampleComponents/ComposedChart/BandedChart.js
+++ b/src/docs/exampleComponents/ComposedChart/BandedChart.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import {
   ComposedChart,
   Line,
@@ -13,79 +13,78 @@ import {
 } from 'recharts';
 
 const data = [
-    {
-      name: "Page A",
-      a: [0, 0],
-      b: 0,
-    },
-    {
-      name: "Page B",
-      a: [50, 300],
-      b: 106,
-    },
-    {
-      name: "Page C",
-      a: [150, 423],
-    },
-    {
-      name: "Page D",
-      b: 312,
-    },
-    {
-      name: "Page E",
-      a: [367, 678],
-      b: 451,
-    },
-    {
-      name: "Page F",
-      a: [305, 821],
-      b: 623,
-    },
-  ];
+  {
+    name: "Page A",
+    a: [0, 0],
+    b: 0,
+  },
+  {
+    name: "Page B",
+    a: [50, 300],
+    b: 106,
+  },
+  {
+    name: "Page C",
+    a: [150, 423],
+  },
+  {
+    name: "Page D",
+    b: 312,
+  },
+  {
+    name: "Page E",
+    a: [367, 678],
+    b: 451,
+  },
+  {
+    name: "Page F",
+    a: [305, 821],
+    b: 623,
+  },
+];
   
-  export default class Example extends PureComponent {
-    renderTooltipWithoutRange = ({ payload, content, ...rest }) => {
-        const newPayload = payload.filter((x) => x.dataKey !== "a");
-        return <Tooltip payload={newPayload} {...rest} />;
-    }
-
-    renderLegendWithoutRange = ({ payload, content, ...rest }) => {
+export function Example() {
+  const renderTooltipWithoutRange = ({ payload, content, ...rest }) => {
       const newPayload = payload.filter((x) => x.dataKey !== "a");
-      return <DefaultLegendContent payload={newPayload} {...rest} />;
-    }
-
-    render() {
-        return (
-          <ResponsiveContainer width="100%" height="100%">
-            <ComposedChart
-            width={500}
-            height={400}
-            data={data}
-            margin={{
-                top: 10,
-                right: 30,
-                left: 0,
-                bottom: 0,
-            }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis />
-              <Tooltip content={this.renderTooltipWithoutRange} />
-              <Area
-                  type="monotone"
-                  dataKey="a"
-                  stroke="none"
-                  fill="#cccccc"
-                  connectNulls
-                  dot={false}
-                  activeDot={false}
-              />
-              <Line type="natural" dataKey="b" stroke="#ff00ff" connectNulls />
-              <Legend content={this.renderLegendWithoutRange} />
-            </ComposedChart>
-          </ResponsiveContainer>
-        );
-    }
+      return <Tooltip payload={newPayload} {...rest} />;
   }
+
+  const renderLegendWithoutRange = ({ payload, content, ...rest }) => {
+    const newPayload = payload.filter((x) => x.dataKey !== "a");
+    return <DefaultLegendContent payload={newPayload} {...rest} />;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <ComposedChart
+      width={500}
+      height={400}
+      data={data}
+      margin={{
+          top: 10,
+          right: 30,
+          left: 0,
+          bottom: 0,
+      }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip content={renderTooltipWithoutRange} />
+        <Area
+            type="monotone"
+            dataKey="a"
+            stroke="none"
+            fill="#cccccc"
+            connectNulls
+            dot={false}
+            activeDot={false}
+        />
+        <Line type="natural" dataKey="b" stroke="#ff00ff" connectNulls />
+        <Legend content={renderLegendWithoutRange} />
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}
   
+Example.demoUrl = 'https://codesandbox.io/p/sandbox/simple-area-chart-forked-hncq3r';

--- a/src/docs/exampleComponents/ComposedChart/BandedChart.js
+++ b/src/docs/exampleComponents/ComposedChart/BandedChart.js
@@ -1,0 +1,83 @@
+import React, { PureComponent } from 'react';
+import {
+  ComposedChart,
+  Line,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+const data = [
+    {
+      name: "Page A",
+      a: [0, 0],
+      b: 0,
+    },
+    {
+      name: "Page B",
+      a: [50, 300],
+      b: 106,
+    },
+    {
+      name: "Page C",
+      a: [150, 423],
+    },
+    {
+      name: "Page D",
+      b: 312,
+    },
+    {
+      name: "Page E",
+      a: [367, 678],
+      b: 451,
+    },
+    {
+      name: "Page F",
+      a: [305, 821],
+      b: 623,
+    },
+  ];
+  
+  export default class Example extends PureComponent {
+    renderTooltipWithoutRange = ({ payload, content, ...rest }) => {
+        const newPayload = payload.filter((x) => x.dataKey !== "a");
+        return <Tooltip payload={newPayload} {...rest} />;
+    }
+
+    render() {
+        return (
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart
+            width={500}
+            height={400}
+            data={data}
+            margin={{
+                top: 10,
+                right: 30,
+                left: 0,
+                bottom: 0,
+            }}
+            >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="name" />
+            <YAxis />
+            <Tooltip content={this.renderTooltipWithoutRange} />
+            <Area
+                type="monotone"
+                dataKey="a"
+                stroke="none"
+                fill="#cccccc"
+                connectNulls
+                dot={false}
+                activeDot={false}
+            />
+            <Line type="natural" dataKey="b" stroke="#ff00ff" connectNulls />
+            </ComposedChart>
+          </ResponsiveContainer>
+        );
+    }
+  }
+  

--- a/src/docs/exampleComponents/ComposedChart/index.js
+++ b/src/docs/exampleComponents/ComposedChart/index.js
@@ -3,6 +3,7 @@ import LineBarAreaComposedChart from './LineBarAreaComposedChart';
 import SameDataComposedChart from './SameDataComposedChart';
 import VerticalComposedChart from './VerticalComposedChart';
 import ScatterAndLineOfBestFit from './ScatterAndLineOfBestFit';
+import BandedChart from './BandedChart'
 
 export default {
   LineBarAreaComposedChart,
@@ -10,4 +11,5 @@ export default {
   VerticalComposedChart,
   ComposedChartWithAxisLabels,
   ScatterAndLineOfBestFit,
+  BandedChart,
 };


### PR DESCRIPTION
Banded graph draws line(s) over a range-like area. Typically it's used to visualize min/max range for whole the data or inside the group.

As defined/discussed in https://github.com/recharts/recharts/issues/316 it's possible for `<Area>` to take tuple of `[min, max]` instead of single value and then it will be drawn as a band. This is not reflected in API/Area section and honestly I have no idea how to document it there in clear way.

So as a first step, I propose to add an example. Example also shows how to filter band data out from tooltip and legend(with custom `content` render callback) and how `connectNulls` works nicely even for such a combination.

![2024-05-25 17_02_20](https://github.com/recharts/recharts.org/assets/956687/b74e55af-8fc4-4b8d-899f-c2a469ffbcc7)

