### PR TITLE
docs(Pie): Add description for rootTabIndex prop in Pie component

### DIFF
--- a/src/docs/api/Pie.js
+++ b/src/docs/api/Pie.js
@@ -264,6 +264,16 @@ export default {
       },
     },
     {
+      name: 'rootTabIndex',
+      type: "Number",
+      defaultVal: "0",
+      isOptional: true,
+      desc: {
+        'en-US': 'The tabindex of wrapper surrounding the cells.',
+        'zh-CN': 'soon',
+      },
+    },
+    {
       name: 'onAnimationStart',
       type: 'Function',
       isOptional: true,


### PR DESCRIPTION
While using recharts, we needed to make it not focusable to consider accessibility.

I couldn't find the relevant api in recharts api docs and I couldn't fix it until I opened the code myself.

To prevent this from happening, add the rootTabIndex information to the Pie component api docs.