### PR TITLE
fix: remove data prop from Bar docs to prevent confusion, fix some typos

### DIFF
--- a/src/docs/api/Area.js
+++ b/src/docs/api/Area.js
@@ -71,7 +71,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, dots will not be drawn. If true set, dots will be drawn which have the props calculated internally. If object set, dots will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom dot element. If set a function, the function will be called to render customized dot.',
+          'If false set, dots will not be drawn. If true set, dots will be drawn which have the props calculated internally. If object set, dots will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom dot element. If set a function, the function will be called to render customized dot.',
         'zh-CN':
           '曲线上的点，接收多种配置。当值为 false ，不渲染点。当值为 true ，点会继承 Area 的属性配置，例如配置了 Area 的 stroke 为 "red"， 点会继承这个属性。当值为一个对象的时候，会把这个对象解析为点的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“点”。当值是函数时，会调用这个函数去渲染自定义的“点”。',
       },
@@ -107,7 +107,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
+          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
         'zh-CN':
           '图形上的文本标签。当值为 false ，不展示文本标签。当值为 true，会根据 Area 的属性配置来展示文本标签。当值为对象的时候，会把这个对象解析为文本标签的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“文本标签”。当值是一个 函数 时，会调用这个函数去渲染自定义的“文本标签”。',
       },
@@ -371,8 +371,8 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the area in this group',
-        'zh-CN': '区域图 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the area in this group',
+        'zh-CN': '区域图 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/Bar.js
+++ b/src/docs/api/Bar.js
@@ -59,7 +59,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
+          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
         'zh-CN':
           '图形上的文本标签。当值为 false ，不展示文本标签。当值为 true，会根据 Bar 的属性配置来展示文本标签。当值为一个对象的时候，会把这个对象解析为 文本标签 的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“文本标签”。当值是一个 函数 时，会调用这个函数去渲染自定义的“文本标签”。',
       },
@@ -70,23 +70,13 @@ export default {
       ],
     },
     {
-      name: 'data',
-      type: 'Array',
-      defaultVal: 'undefined',
-      isOptional: false,
-      desc: {
-        'en-US': 'The position information of all the rectangles, usually calculated internally.',
-        'zh-CN': '描述所有柱条的坐标、尺寸数据。',
-      },
-    },
-    {
       name: 'barSize',
       type: 'Number | Percentage',
       defaultVal: 'undefined',
       isOptional: true,
       desc: {
         'en-US':
-          'The width or height of each bar. If the barSize is not specified, the size of bar will be caculated by the barCategoryGap, barGap and the quantity of bar groups.',
+          'The width or height of each bar. If the barSize is not specified, the size of bar will be calculated by the barCategoryGap, barGap and the quantity of bar groups.',
         'zh-CN':
           '柱条的宽度。如果指定这个值，会根据 barCategoryGap 和 barGap 来计算柱条的宽度，每组柱条的宽度是一样的。',
       },
@@ -127,7 +117,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, background of bars will not be drawn. If true set, background of bars will be drawn which have the props calculated internally. If object set, background of bars will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom background element. If set a function, the function will be called to render customized background.',
+          'If false set, background of bars will not be drawn. If true set, background of bars will be drawn which have the props calculated internally. If object set, background of bars will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom background element. If set a function, the function will be called to render customized background.',
         'zh-CN':
           '是否显示背景柱条。当值为 false ，不展示背景柱条。当值为 true，会根据 RadialBar 的属性配置来展示背景柱条。当值为一个对象的时候，会把这个对象解析为 背景柱条 的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“背景柱条”。当值是一个 函数 时，会调用这个函数去渲染自定义的“背景柱条”。',
       },
@@ -367,7 +357,7 @@ export default {
       isOptional: true,
       desc: {
         'en-US': 'The customized event handler of mouseenter on the bars in this group',
-        'zh-CN': '柱条 moustenter 事件的回调函数。',
+        'zh-CN': '柱条 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/Curve.js
+++ b/src/docs/api/Curve.js
@@ -134,8 +134,8 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the curve',
-        'zh-CN': '曲线 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the curve',
+        'zh-CN': '曲线 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/Funnel.js
+++ b/src/docs/api/Funnel.js
@@ -35,7 +35,7 @@ export default {
     {
       name: 'legendType',
       type:
-      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+        "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'line'",
       isOptional: true,
       desc: {
@@ -49,7 +49,7 @@ export default {
       defaultVal: 'undefined',
       isOptional: true,
       desc: {
-        'en-US': "The customized shape to be rendered if shape is active via Tooltip, or active index prop is set.",
+        'en-US': 'The customized shape to be rendered if shape is active via Tooltip, or active index prop is set.',
         'zh-CN': '如果形状通过工具提示处于活动状态，或设置了活动索引道具，则将渲染自定义形状。',
       },
     },
@@ -59,7 +59,7 @@ export default {
       defaultVal: 'undefined',
       isOptional: true,
       desc: {
-        'en-US': "The customized shape to be rendered.",
+        'en-US': 'The customized shape to be rendered.',
         'zh-CN': '要渲染的自定义形状。',
       },
     },
@@ -208,8 +208,8 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the area in this group',
-        'zh-CN': '曲线 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the area in this group',
+        'zh-CN': '曲线 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/Legend.js
+++ b/src/docs/api/Legend.js
@@ -258,8 +258,8 @@ const renderLegend = (props) => {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the items in this group',
-        'zh-CN': '图例每个项目 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the items in this group',
+        'zh-CN': '图例每个项目 mouseenter 事件的回调函数。',
       },
       examples: [
         {

--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -56,7 +56,8 @@ export default {
     },
     {
       name: 'legendType',
-      type: "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+      type:
+        "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'line'",
       isOptional: true,
       desc: {
@@ -71,7 +72,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, dots will not be drawn. If true set, dots will be drawn which have the props calculated internally. If object set, dots will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom dot element.If set a function, the function will be called to render customized dot.',
+          'If false set, dots will not be drawn. If true set, dots will be drawn which have the props calculated internally. If object set, dots will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom dot element.If set a function, the function will be called to render customized dot.',
         'zh-CN':
           '曲线上的点，接收多种配置。当值为 false ，不渲染点。当值为 true ，点会继承 Line 的属性配置，例如配置了 Area 的 stroke 为 "red"， 点会继承这个属性。当值为一个对象的时候，会把这个对象解析为点的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“点”。当值是一个 函数 时，会调用这个函数去渲染自定义的“点”。',
       },
@@ -119,7 +120,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
+          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
         'zh-CN':
           '图形上的文本标签。当值为 false ，不展示文本标签。当值为 true，会根据 Line 的属性配置来展示文本标签。当值为一个对象的时候，会把这个对象解析为 文本标签 的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“文本标签”。当值是一个 函数 时，会调用这个函数去渲染自定义的“文本标签”。',
       },
@@ -363,8 +364,8 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the area in this group',
-        'zh-CN': '曲线 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the area in this group',
+        'zh-CN': '曲线 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/Pie.js
+++ b/src/docs/api/Pie.js
@@ -127,7 +127,7 @@ export default {
     {
       name: 'legendType',
       type:
-      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+        "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'rect'",
       isOptional: false,
       desc: {
@@ -142,7 +142,7 @@ export default {
       isOptional: true,
       desc: {
         'en-US':
-          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
+          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
         'zh-CN':
           '图形上的文本标签。当值为 false ，不展示文本标签。当值为 true，会根据 Bar 的属性配置来展示文本标签。当值为一个对象的时候，会把这个对象解析为 文本标签 的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“文本标签”。当值是一个 函数 时，会调用这个函数去渲染自定义的“文本标签”。',
       },
@@ -160,7 +160,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, label lines will not be drawn. If true set, label lines will be drawn which have the props calculated internally. If object set, label lines will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom label line element. If set a function, the function will be called to render customized label line.',
+          'If false set, label lines will not be drawn. If true set, label lines will be drawn which have the props calculated internally. If object set, label lines will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom label line element. If set a function, the function will be called to render customized label line.',
         'zh-CN':
           '文本标签与楔子的连线。当值为 false ，不展示连线。当值为 true，会根据 Bar 的属性配置来展示连线。当值为一个对象的时候，会把这个对象解析为 连线 的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“连线”。当值是一个 函数 时，会调用这个函数去渲染自定义的“连线”。',
       },
@@ -265,8 +265,8 @@ export default {
     },
     {
       name: 'rootTabIndex',
-      type: "Number",
-      defaultVal: "0",
+      type: 'Number',
+      defaultVal: '0',
       isOptional: true,
       desc: {
         'en-US': 'The tabindex of wrapper surrounding the cells.',

--- a/src/docs/api/PolarAngleAxis.js
+++ b/src/docs/api/PolarAngleAxis.js
@@ -50,7 +50,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, axis line will not be drawn. If true set, axis line will be drawn which have the props calculated internally. If object set, axis line will be drawn which have the props mergered by the internal calculated props and the option.',
+          'If false set, axis line will not be drawn. If true set, axis line will be drawn which have the props calculated internally. If object set, axis line will be drawn which have the props merged by the internal calculated props and the option.',
         'zh-CN': '轴线配置。当值为 false 时，不绘制轴线。当值为对象类型时，会把这个对象解析成 轴线 的属性配置。',
       },
     },
@@ -71,7 +71,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, tick lines will not be drawn. If true set, tick lines will be drawn which have the props calculated internally. If object set, tick lines will be drawn which have the props mergered by the internal calculated props and the option.',
+          'If false set, tick lines will not be drawn. If true set, tick lines will be drawn which have the props calculated internally. If object set, tick lines will be drawn which have the props merged by the internal calculated props and the option.',
         'zh-CN': '刻度线配置。当值为 false 时，不绘制刻度线。当值为对象类型时，会把这个对象解析成 刻度线 的属性配置。',
       },
     },
@@ -82,7 +82,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, ticks will not be drawn. If true set, ticks will be drawn which have the props calculated internally. If object set, ticks will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom tick element. If set a function, the function will be called to render customized ticks.',
+          'If false set, ticks will not be drawn. If true set, ticks will be drawn which have the props calculated internally. If object set, ticks will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom tick element. If set a function, the function will be called to render customized ticks.',
         'zh-CN':
           '刻度配置。当值为 false 时，不绘制刻度。当值为对象类型时，会把这个对象解析成 刻度 的属性配置。当值为 React element，会克隆这个元素来渲染刻度。',
       },
@@ -196,8 +196,8 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the ticks of this axis',
-        'zh-CN': '刻度 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the ticks of this axis',
+        'zh-CN': '刻度 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/PolarRadiusAxis.js
+++ b/src/docs/api/PolarRadiusAxis.js
@@ -66,7 +66,7 @@ export default {
         "<PolarRadiusAxis domain={['dataMin', 'dataMax']} />",
         "<PolarRadiusAxis domain={[0, 'dataMax']} />",
         "<PolarRadiusAxis domain={['auto', 'auto']} />",
-        "<PolarRadiusAxis domain={([dataMin, dataMax]) => { const absMax = Math.max(Math.abs(dataMin), Math.abs(dataMax)); return [-absMax, absMax]; }} />",
+        '<PolarRadiusAxis domain={([dataMin, dataMax]) => { const absMax = Math.max(Math.abs(dataMin), Math.abs(dataMax)); return [-absMax, absMax]; }} />',
       ],
     },
     {
@@ -108,7 +108,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, axis line will not be drawn. If true set, axis line will be drawn which have the props calculated internally. If object set, axis line will be drawn which have the props mergered by the internal calculated props and the option.',
+          'If false set, axis line will not be drawn. If true set, axis line will be drawn which have the props calculated internally. If object set, axis line will be drawn which have the props merged by the internal calculated props and the option.',
         'zh-CN': '刻度线配置。当值为 false 时，不绘制刻度线。当值为对象类型时，会把这个对象解析成刻度线的属性配置。',
       },
     },
@@ -119,7 +119,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, ticks will not be drawn. If true set, ticks will be drawn which have the props calculated internally. If object set, ticks will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom tick element. If set a function, the function will be called to render customized ticks.',
+          'If false set, ticks will not be drawn. If true set, ticks will be drawn which have the props calculated internally. If object set, ticks will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom tick element. If set a function, the function will be called to render customized ticks.',
         'zh-CN':
           '刻度配置。当值为 false 时，不绘制刻度。当值为对象类型时，会把这个对象解析成刻度的属性配置。当值为 React element，会克隆这个元素来渲染刻度。',
       },
@@ -226,8 +226,8 @@ const scale = scaleLog().base(Math.E);
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the ticks of this axis',
-        'zh-CN': '刻度 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the ticks of this axis',
+        'zh-CN': '刻度 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/Polygon.js
+++ b/src/docs/api/Polygon.js
@@ -70,8 +70,8 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the polygon',
-        'zh-CN': '多边形 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the polygon',
+        'zh-CN': '多边形 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/Radar.js
+++ b/src/docs/api/Radar.js
@@ -39,7 +39,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, dots will not be drawn. If true set, dots will be drawn which have the props calculated internally. If object set, dots will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom dot element. If set a function, the function will be called to render customized dot.',
+          'If false set, dots will not be drawn. If true set, dots will be drawn which have the props calculated internally. If object set, dots will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom dot element. If set a function, the function will be called to render customized dot.',
         'zh-CN':
           '“雷达”多边形上的点，接收多种配置。当值为 false，不渲染点。当值为 true，点会继承 Radar 的属性配置，例如配置了 Radar 的 stroke 为 "red"， 点会继承这个属性。当值为一个对象的时候，会把这个对象解析为点的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“点”。当值是函数时，会调用这个函数去渲染自定义的“点”。',
       },
@@ -47,7 +47,7 @@ export default {
     {
       name: 'legendType',
       type:
-      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+        "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'rect'",
       isOptional: true,
       desc: {
@@ -62,7 +62,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
+          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
         'zh-CN':
           '图形上的文本标签。当值为 false，不展示文本标签。当值为 true，会根据 Bar 的属性配置来展示文本标签。当值为一个对象的时候，会把这个对象解析为文本标签的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“文本标签”。当值是函数时，会调用这个函数去渲染自定义的“文本标签”。',
       },

--- a/src/docs/api/RadialBar.js
+++ b/src/docs/api/RadialBar.js
@@ -70,7 +70,7 @@ export default {
     {
       name: 'legendType',
       type:
-      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+        "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'rect'",
       isOptional: true,
       desc: {
@@ -85,7 +85,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
+          'If false set, labels will not be drawn. If true set, labels will be drawn which have the props calculated internally. If object set, labels will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom label element. If set a function, the function will be called to render customized label.',
         'zh-CN':
           '图形上的文本标签。当值为 false ，不展示文本标签。当值为 true，会根据 Bar 的属性配置来展示文本标签。当值为一个对象的时候，会把这个对象解析为 文本标签 的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“文本标签”。当值是一个 函数 时，会调用这个函数去渲染自定义的“文本标签”。',
       },
@@ -97,7 +97,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, background of bars will not be drawn. If true set, background of bars will be drawn which have the props calculated internally. If object set, background of bars will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom background element. If set a function, the function will be called to render customized background.',
+          'If false set, background of bars will not be drawn. If true set, background of bars will be drawn which have the props calculated internally. If object set, background of bars will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom background element. If set a function, the function will be called to render customized background.',
         'zh-CN':
           '是否显示背景柱条。当值为 false ，不展示背景柱条。当值为 true，会根据 RadialBar 的属性配置来展示背景柱条。当值为一个对象的时候，会把这个对象解析为 背景柱条 的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“背景柱条”。当值是一个 函数 时，会调用这个函数去渲染自定义的“背景柱条”。',
       },
@@ -229,8 +229,8 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the sectors in this group',
-        'zh-CN': '柱条 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the sectors in this group',
+        'zh-CN': '柱条 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/Rectangle.js
+++ b/src/docs/api/Rectangle.js
@@ -112,8 +112,8 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the rectangle',
-        'zh-CN': '矩形 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the rectangle',
+        'zh-CN': '矩形 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/Scatter.js
+++ b/src/docs/api/Scatter.js
@@ -4,7 +4,7 @@ export default {
     {
       name: 'legendType',
       type:
-      "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+        "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'circle'",
       isOptional: true,
       desc: {
@@ -49,7 +49,7 @@ export default {
       isOptional: false,
       desc: {
         'en-US':
-          'If false set, line will not be drawn. If true set, line will be drawn which have the props calculated internally. If object set, line will be drawn which have the props mergered by the internal calculated props and the option. If ReactElement set, the option can be the custom line element. If set a function, the function will be called to render Customized line.',
+          'If false set, line will not be drawn. If true set, line will be drawn which have the props calculated internally. If object set, line will be drawn which have the props merged by the internal calculated props and the option. If ReactElement set, the option can be the custom line element. If set a function, the function will be called to render Customized line.',
         'zh-CN':
           '如果值为 false，不会渲染相应的曲线。当值为 true，会根据 Scatter 的属性配置来展示曲线。当值为一个对象的时候，会把这个对象解析为 曲线 的属性，来覆盖默认属性。当值是一个 React Element ，会克隆这个 React Element 来渲染“曲线”。当值是一个 函数 时，会调用这个函数去渲染自定义的“曲线”。',
       },
@@ -209,8 +209,8 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the symbols in this group',
-        'zh-CN': '散点 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the symbols in this group',
+        'zh-CN': '散点 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/ScatterChart.js
+++ b/src/docs/api/ScatterChart.js
@@ -91,8 +91,8 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter in this chart.',
-        'zh-CN': '鼠标在图表图形区域 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter in this chart.',
+        'zh-CN': '鼠标在图表图形区域 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/Sector.js
+++ b/src/docs/api/Sector.js
@@ -140,8 +140,8 @@ export default {
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the sector',
-        'zh-CN': '楔子 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the sector',
+        'zh-CN': '楔子 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/XAxis.js
+++ b/src/docs/api/XAxis.js
@@ -92,9 +92,7 @@ export default {
         'zh-CN':
           '当轴是数值轴时，指定轴的定义域（domain）的时候，如果 allowDataOverflow 的值为 false，我们会根据数据的最大值和最小值来调整 domain，确保所有的数据能够展示。如果 allowDataOverflow 的值为 true，不会调整 domain ，而是将相应的图形元素会直接裁剪掉。',
       },
-      format: [
-        '<XAxis type="number" domain={[0, 100]} allowDataOverflow />' 
-      ],
+      format: ['<XAxis type="number" domain={[0, 100]} allowDataOverflow />'],
     },
     {
       name: 'allowDuplicatedCategory',
@@ -157,17 +155,14 @@ export default {
     {
       name: 'includeHidden',
       type: 'Boolean',
-      defaultVal: "false",
+      defaultVal: 'false',
       isOptional: true,
       desc: {
         'en-US':
-          "Ensures that all datapoints within a chart contribute to its domain calculation, even when they are hidden",
-        'zh-CN':
-          '确保图表中的所有数据点都有助于其域计算，即使它们被隐藏时也是如此',
+          'Ensures that all datapoints within a chart contribute to its domain calculation, even when they are hidden',
+        'zh-CN': '确保图表中的所有数据点都有助于其域计算，即使它们被隐藏时也是如此',
       },
-      format: [
-        "<XAxis type=\"number\" includeHidden />",
-      ],
+      format: ['<XAxis type="number" includeHidden />'],
     },
     {
       name: 'interval',
@@ -444,8 +439,8 @@ const scale = scaleLog().base(Math.E);
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the ticks of this axis',
-        'zh-CN': '刻度 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the ticks of this axis',
+        'zh-CN': '刻度 mouseenter 事件的回调函数。',
       },
     },
     {

--- a/src/docs/api/YAxis.js
+++ b/src/docs/api/YAxis.js
@@ -100,7 +100,7 @@ export default {
         "<YAxis type=\"number\" domain={['dataMin - 100', 'dataMax + 100']} />",
         '<YAxis type="number" domain={[dataMin => (0 - Math.abs(dataMin)), dataMax => (dataMax * 2)]} />',
         '<YAxis type="number" domain={([dataMin, dataMax]) => { const absMax = Math.max(Math.abs(dataMin), Math.abs(dataMax)); return [-absMax, absMax]; }} />',
-        '<YAxis type="number" domain={[0, 100]} allowDataOverflow />' 
+        '<YAxis type="number" domain={[0, 100]} allowDataOverflow />',
       ],
       examples: [
         {
@@ -191,9 +191,7 @@ export default {
         'zh-CN':
           '当轴是数值轴时，指定轴的定义域（domain）的时候，如果 allowDataOverflow 的值为 false，我们会根据数据的最大值和最小值来调整 domain，确保所有的数据能够展示。如果 allowDataOverflow 的值为 true，不会调整 domain ，而是将相应的图形元素会直接裁剪掉。',
       },
-      format: [
-        '<YAxis type="number" domain={[0, 100]} allowDataOverflow />'
-      ]
+      format: ['<YAxis type="number" domain={[0, 100]} allowDataOverflow />'],
     },
     {
       name: 'allowDuplicatedCategory',
@@ -422,8 +420,8 @@ const scale = scaleLog().base(Math.E);
       type: 'Function',
       isOptional: true,
       desc: {
-        'en-US': 'The customized event handler of moustenter on the ticks of this axis',
-        'zh-CN': '刻度 moustenter 事件的回调函数。',
+        'en-US': 'The customized event handler of mouseenter on the ticks of this axis',
+        'zh-CN': '刻度 mouseenter 事件的回调函数。',
       },
     },
     {


### PR DESCRIPTION
https://github.com/recharts/recharts/issues/5264#issuecomment-2498993561

We're misrepresenting the `Bar` API by having the `data` prop present in the docs even though it states "usually calculated internally"

In reality it can currently "only be calculated internally"

So remove it until 3.x when it can be actually used as a prop for adding data-per series

Also found a bunch of typos so fix those too