### PR TITLE
chore: remove duplicate entry in Line documentation

### DIFF
--- a/src/docs/api/Line.js
+++ b/src/docs/api/Line.js
@@ -57,7 +57,7 @@ export default {
     {
       name: 'legendType',
       type:
-        "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'square' | 'star' | 'triangle' | 'wye' | 'none'",
+        "'line' | 'plainline' | 'square' | 'rect'| 'circle' | 'cross' | 'diamond' | 'star' | 'triangle' | 'wye' | 'none'",
       defaultVal: "'line'",
       isOptional: true,
       desc: {


### PR DESCRIPTION
'square' was written twice in the legend type