### PR TITLE
Enable TypeScript Support for Example Codes in Monaco Editor

### DIFF
--- a/src/components/Shared/StackBlitzLink.tsx
+++ b/src/components/Shared/StackBlitzLink.tsx
@@ -3,7 +3,7 @@ import stackblitzSdk, { ProjectDependencies } from '@stackblitz/sdk';
 import { TargetBlankLink } from './TargetBlankLink.tsx';
 import { sendEvent } from '../analytics.ts';
 
-type StackBlitzLinkProps = {
+type StackBlitzLinkProps = Readonly<{
   /**
    * The code to be included in the StackBlitz project.
    */
@@ -17,11 +17,11 @@ type StackBlitzLinkProps = {
    * The children to be rendered inside the link.
    */
   children: ReactNode;
-};
+}>;
 
 // React 18+ boilerplate
-// language=jsx
-const indexJsCode = `
+// language=tsx
+const indexTsxCode = `
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import Example from './Example';
@@ -37,12 +37,24 @@ const indexHtmlCode = `<div id="root" style="width: 100vw; height: 100vh;" />`;
 const tsconfigJsonCode = `{
   "compilerOptions": {
     "target": "es5",
+    "lib": ["dom", "dom.iterable", "es6"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "jsx": "react-jsx",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-  }
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ]
 }`;
 
 const dependencies: ProjectDependencies = {
@@ -52,13 +64,14 @@ const dependencies: ProjectDependencies = {
   recharts: '^3.1.0',
   '@types/react': '^19.0.0',
   '@types/react-dom': '^19.0.0',
+  typescript: '^5.0.0',
 };
 
 /*
  * This creates a link that creates a new StackBlitz project
  * with the provided code and opens it in a new tab.
  * This assumes that the code is a Recharts example component which exports the React component as the default export.
- * This uses a javascript template, no typescript support in this one.
+ * This uses TypeScript with full type checking enabled.
  */
 export function StackBlitzLink({ code, title, children }: StackBlitzLinkProps) {
   return (
@@ -84,9 +97,9 @@ export function StackBlitzLink({ code, title, children }: StackBlitzLinkProps) {
             files: {
               'public/index.html': indexHtmlCode,
               /*
-               * This file has jsx in it, but create-react-app requires that the entry point is a src/index.ts file.
+               * This file has tsx in it, and create-react-app supports TypeScript out of the box.
                */
-              'src/index.js': indexJsCode,
+              'src/index.tsx': indexTsxCode,
               'src/Example.tsx': code,
               'tsconfig.json': tsconfigJsonCode,
             },

--- a/src/views/ExamplesView.tsx
+++ b/src/views/ExamplesView.tsx
@@ -32,7 +32,7 @@ const parseExampleComponent = (compName: string): ExampleComponent | null => {
     return !!entry.examples[compName];
   });
 
-  if (res && res.length) {
+  if (res?.length) {
     return {
       cateName: res[0],
       exampleName: compName,
@@ -129,12 +129,18 @@ class ExamplesView extends PureComponent<ExamplesViewProps, ExamplesViewState> {
           <Editor
             key={`editor-${exampleResult.exampleName}`}
             value={this.state.exampleCode}
-            defaultLanguage="javascript"
+            defaultLanguage="typescript"
             options={{ tabSize: 2 }}
             onMount={(editor) => {
               // @ts-ignore
               // noinspection JSConstantReassignment
               this.editorRef.current = editor;
+            }}
+            beforeMount={(monaco) => {
+              monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
+                jsx: monaco.languages.typescript.JsxEmit.React, // enables TSX/JSX
+                allowJs: true,
+              });
             }}
           />
         </div>


### PR DESCRIPTION
### Pull Request: Enable TypeScript Support for Example Codes in Monaco Editor
#### Description

This pull request resolves the issue where example code snippets in the Monaco editor lacked TypeScript language support. With these changes, TypeScript features—including syntax highlighting, type checking, autocompletion, and error reporting—are now enabled for all relevant example snippets.

#### Changes Introduced

- Updated the Monaco editor configuration to ensure example codes are set to the `typescript` language where applicable.
- Verified that TypeScript language services are active for example snippets.
- Improved documentation to clarify TypeScript support in examples.

#### Related Issue

Fixes #390 

### Solved Screenshot
<img width="1467" height="839" alt="image" src="https://github.com/user-attachments/assets/e894c4dc-6cbb-4849-b471-d68c56ba8c41" />


#### Testing

- Confirmed that TypeScript syntax highlighting is present in example codes.
- Verified that type checking and autocompletion work as expected.
- Checked compatibility across supported browsers and environments.
